### PR TITLE
Support transparent sample storage growth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,10 @@
 # Agent Notes (jaxns)
 
 - The Agent should have read LEARNINGS.md.
+- Optional orientation: if the intended system behavior, scientific model, or
+  collaboration style is still unclear, read [COMMON_CONTEXT.md](COMMON_CONTEXT.md)
+  before acting. It is a mental-model aid, not a substitute for the current
+  requirements, invariants, design docs, paper, or code.
 
 ## Repo Layout
 
@@ -94,6 +98,34 @@ Additional conventions (helpful when adding new code):
 
 ## Agent Workflow Expectations
 
+- Assume other agents may be working in parallel. For work intended for a PR,
+  create a dedicated worktree and PR branch from the correct base; do not edit
+  the primary checkout unless the user explicitly asks you to update that
+  checkout directly.
+- Worktree isolation prevents file conflicts, not design conflicts. Before
+  changing code, identify the feature's ownership and existing semantic
+  boundaries. Do not force a new feature into a nearby pattern merely because
+  the pattern exists; first verify that its intent, lifecycle, and consumers
+  actually match.
+- Work may span many files when it remains inside an understood boundary and
+  the human and agent share a strong, concrete intention and the human
+  understands and owns the scientific or product decision being made. If the
+  work would change a shared contract, cross into another feature's ownership,
+  or create a new boundary, stop before implementing that part and explain the
+  crossing to the user. Recommend coordination with the relevant contributors
+  rather than designing a shared boundary in isolation.
+- Help the user see boundary crossings early. A surprising need to reach into
+  another subsystem is evidence that the task or human intent may not yet be
+  understood; trace the ownership and data flow, then clarify instead of
+  allowing the feature to diffuse through unrelated code.
+- Every PR must track its work in a GitHub issue. If the user requests a PR but
+  does not provide an issue, create one and link the PR to it. Ephemeral
+  investigation and exploratory work do not require an issue unless the user
+  asks for one; if that work becomes a PR, create or identify its issue before
+  opening the PR.
+- After a PR is merged, remove its worktree. If its remote branch was deleted,
+  delete the local PR branch too. Keep the primary checkout on the intended
+  base branch and do not accumulate stale worktrees or branches.
 - Keep changes scoped to one package unless intentionally cross-cutting.
 - Add/adjust tests with behavior changes; run `pytest` + `flake8` + `ruff` for the touched package.
 - Don’t add repo-wide tooling/config unless asked; propose it if it would materially help.

--- a/COMMON_CONTEXT.md
+++ b/COMMON_CONTEXT.md
@@ -1,0 +1,273 @@
+# Common Context for Working on jaxns
+
+This is an opt-in orientation for an agent that has read `AGENTS.md` and the
+relevant design material but still does not feel it understands the system or
+the human intent. It captures recurring reasoning and collaboration patterns
+from prior work with JoshuaAlbert. It is deliberately not a requirements
+document. When it conflicts with current code, requirements, invariants, the
+paper, or an explicit instruction, those sources win.
+
+## The Shortest Useful Version
+
+Aim for **correctness and completeness first, with performance and
+maintainability treated as joint design constraints**. Understand the whole
+state flow before changing a local function. Do not call something a bug,
+improvement, or performance win without evidence. Once a real bug is found,
+fix it narrowly, demonstrate the regression before and after, and record any
+new requirement or invariant it revealed.
+
+Write code whose intention a human can assert. Prefer a linear implementation
+that reads top to bottom, clear Pytree/module ownership, and comments explaining
+non-obvious consequences. Reuse existing mechanisms. Look for sprawl,
+duplicated concepts, stale alternatives, and code that has become purposeless.
+
+## How JoshuaAlbert Reasons With Agents
+
+JoshuaAlbert often starts with a proposal while explicitly saying that it may
+not be complete. Treat it as a serious model to compare against the current
+system, not as either a loose suggestion or an instruction to agree blindly.
+Identify sameness and divergence, fill gaps from the code and evidence, and
+challenge a detail when the implementation or underlying library proves
+otherwise.
+
+> I don't claim my thoughts to be complete; together we can identify sameness
+> and divergence.
+
+JoshuaAlbert may add a refinement while the agent is still investigating or
+may review an answer by questioning one premise at a time. Integrate those
+messages into the same model. Do not treat each correction as an isolated
+patch or lose the still-valid parts of the earlier request.
+
+The recurring standard is:
+
+> correctness and completeness of logic and state flow; performance and
+> scalability using smart composition that avoids unnecessary movement; and
+> maintainability through clear code intent and modularity
+
+JoshuaAlbert supplies domain corrections quickly and expects the agent to
+absorb the underlying contract, not merely patch the sentence that triggered
+the correction. When he says that an idea is fictitious in the real world,
+remove the invented dependency from the model. When he distinguishes a
+scientific contract from an implementation detail, tests and docs should
+preserve the contract without unnecessarily freezing the implementation.
+
+It is good to say, with evidence, “the coercion is wrong, but the correct type
+is integer rather than float.” It is not good to silently defer, guess, or
+retrofit evidence around the first proposed answer.
+
+## Reconstruct Intent Before Acting
+
+When context is weak, walk the complete path relevant to the task:
+
+1. Identify the external input, canonical source, ownership boundary, and
+   output or side effect.
+2. Trace how state is initialized, updated, routed, persisted, and presented.
+3. Separate scientific and user-facing contracts from current implementation
+   choices and historical leftovers.
+4. State the inferred contract concretely enough that it can be tested.
+5. Inspect requirements, invariants, design docs, the paper, tests, maintained
+   configs, and the real call path—not only the file named in the request.
+
+Do not use an example, stale branch, rendering, or accidental current behavior
+as the source of truth when a maintained contract exists. Conversely, do not
+preserve an old abstraction merely because it has tests if the project has
+deliberately moved on.
+
+## Evidence and Diagnosis
+
+JoshuaAlbert prefers diagnosis in order of likelihood, with instrumentation
+and controlled experiments when necessary. A useful investigation normally:
+
+- chooses an independent baseline whose semantics are understood;
+- makes the discrepancy reproducible;
+- compares like with like, including termination conditions, live or root
+  lineage counts, sampler settings, phantom handling, precision, and hardware;
+- adds temporary diagnostics at the narrowest useful boundary;
+- records experimental results so work can resume after interruption;
+- distinguishes a demonstrated cause from noise or a plausible theory; and
+- removes temporary diagnostics after the cause is established.
+
+If asked to diagnose, do not rush into a fix. Present the cause and evidence
+for review first. Once a fix is approved, use targeted A/B testing so the
+result proves that the identified cause—not an incidental change—moved the
+outcome.
+
+Phrases such as “strong evidence” and “forensic” are literal expectations.
+For performance work, report compilation and steady-state runtime separately
+when relevant, compare before and after on realistic shapes and production
+composition, and check the complete path rather than relying on a flattering
+microbenchmark. Performance work may require several iterations. For
+statistical or stochastic behavior, use enough seeds and report dispersion;
+three convenient runs are not strong evidence when thirty are practical.
+
+## Correctness Discipline
+
+If work uncovers a real bug, add a regression test. Demonstrate that the test
+fails before the fix and passes after it. If the bug reveals a new invariant or
+requirement, record it and map its test coverage.
+
+Not every design change needs a new test that freezes its present structure.
+Tests should preserve externally meaningful behavior, requirements, and
+invariants. Implementation-specific tests are appropriate when a real
+implementation requirement exists; incidental decomposition is not a
+contract.
+
+Do not add runtime checks merely to compensate for a contract that construction
+or tests can guarantee. State ownership, fixed shapes, and schema validation
+should live at the boundary that actually owns them. Runtime hot paths should
+not accumulate redundant projections and defensive work “just in case.”
+
+Random state is scientific state. When a compiled depth loop returns to Python
+for orchestration, resizing, or goal evaluation, verify which key represents
+the immediate continuation and which key belongs to the next logical epoch.
+A transparent interruption must not silently change the sampler trajectory.
+
+“Surgical” means the smallest coherent change, not a shallow one. If a
+correctness premise changes, carry it through every semantically equivalent
+path—expectation and Monte Carlo, classic and phantom-conditioned, runtime and
+paper/model—so the system does not retain two meanings. Do not opportunistically
+refactor unrelated code while doing so.
+
+## Design and Code Intent
+
+Prefer semantic states and transitions over mechanical decomposition. Linear
+steps with no conditional gate usually belong in one callback or function,
+because an unconditional state transition does not express a decision.
+
+For competing implementations:
+
+- keep the public contract and test preparation shared where possible;
+- parameterize contract/invariant tests across implementations;
+- keep implementation-specific requirement tests beside that implementation;
+- make each implementation modular enough to remove cleanly;
+- benchmark realistic end-to-end composition; and
+- once a production choice is made, remove legacy choices and naming rather
+  than retaining switches with no product purpose.
+
+A parallel implementation is not truly modular if deleting it requires
+untangling production code, shared docs, and unrelated tests. “Could we safely
+delete one folder and one test folder?” is a useful design pressure even when
+the final layout shares contract tests.
+
+Use existing state, result, sample, ordering, termination, and serialization
+machinery before creating another version. Duplication is sometimes clearer
+than an abstraction with excessive mental plumbing, but duplicated concepts or
+sources of truth are dangerous.
+
+Prefer removing unnecessary representation work over making it faster. If data
+is already packed, do not flatten and concatenate it again. Before adding an
+index, register, projection, diagnostic, or compatibility layer, ask what
+consumer needs it and which invariant owns it. Sorting, batching, and resizing
+often make redundant identity state actively misleading.
+
+For JAX-heavy code, keep the physical model readable by eye:
+
+- show important array shapes beside fields and transformations;
+- give each module a cohesive Pytree state rather than a monolithic union of
+  every possible field;
+- use structured `lax.cond`/`lax.switch` control flow when it expresses the
+  semantic branches more clearly, then inspect compilation rather than
+  guessing what it lowers to;
+- avoid materialization, movement, and fictitious updates that the chosen
+  static composition does not require;
+- preserve batched replacement sampling unless evidence supports changing the
+  execution model; and
+- put rare capacity growth in a transparent orchestration boundary when that
+  keeps resizing and recompilation out of the steady-state kernel.
+
+User-facing result and state objects should expose the conceptual model.
+Cluster secondary diagnostics in a named Pytree instead of crowding essential
+results, and avoid version suffixes or legacy adapters unless a real consumer
+needs simultaneous compatibility. Backward compatibility has a cost; do not
+pay it for a hypothetical user who would necessarily rebuild or rerun.
+
+## Compact JAXNS Mental Model
+
+The scientific path repeatedly separates concepts that are easy to conflate:
+
+- model: prior transformation and likelihood evaluation;
+- constrained sampling: stationary generation above a strict contour;
+- scheduling: selection and advancement of logical lineage threads;
+- shrinkage: race-tree inference, optionally conditioned on phantom Monte
+  Carlo observations; and
+- presentation: immutable state and result Pytrees used by scientific users.
+
+A useful high-level execution sketch is:
+
+```text
+model + random key + user goal condition
+        -> Python goal-level orchestration
+        -> jitted depth loop and lineage allocation
+        -> vmapped constrained-prior replacement sampling
+        -> samples, contours, out-degrees, and phantom clusters
+        -> expectation or Monte Carlo shrinkage
+        -> evidence and posterior result objects
+```
+
+The race-tree formulation makes parent likelihood contours and sample
+out-degrees the essential scheduling information; do not add mutable identity
+state without a demonstrated consumer. The inner depth loop is pure JAX and
+performance sensitive. The outer loop is Pythonic so user goal conditions,
+rare storage growth, and future distributed orchestration can remain outside
+the steady-state kernel.
+
+Expectation estimates are suitable for cheap depth decisions. Final
+user-facing evidence calculations use Monte Carlo shrinkage, with optional
+phantom conditioning. Phantom states are Monte Carlo observations, not
+independent race participants, and their stationarity and atom/no-atom
+semantics are correctness requirements.
+
+This sketch is orientation only. Read the current paper, requirements,
+invariants, design documents, and implementation before relying on a detail.
+
+## Collaboration and Operational Hygiene
+
+JoshuaAlbert often says “you are not alone.” Assume other agents may be
+working in parallel. PR work belongs in a dedicated worktree and issue-backed
+PR branch unless JoshuaAlbert explicitly asks for changes in the primary
+checkout. Inspect other worktrees and dirty files before editing, and keep the
+task modular enough to avoid conflicts.
+
+Worktree isolation is not architectural coordination. Identify the ownership
+and semantic boundary of the feature before borrowing an existing pattern or
+touching a neighboring subsystem. A pattern with the wrong intent, lifecycle,
+or consumers is worse than a little local duplication. Larger steps are fine
+inside a well-understood boundary when JoshuaAlbert and the agent share a
+concrete intention and JoshuaAlbert understands and owns the scientific or
+product decision. If the work needs a new shared boundary, changes another
+feature's contract, or crosses into a colleague's ownership, surface that fact
+before implementation and ask JoshuaAlbert to coordinate with the relevant
+contributors. Developing that contract in a vacuum risks diffusing a locally
+plausible but globally wrong model through the codebase.
+
+An unexpected boundary crossing is also a diagnostic: the agent may not yet
+understand the human intent or complete data flow. Help the human see the
+crossing, trace it, and clarify it rather than silently expanding the task.
+Ephemeral exploration does not need an issue merely because it happened; issue
+tracking becomes mandatory when the work is made into a PR. Make long sweeps
+and evaluations resumable because the laptop may move or the work may be
+interrupted. Give concrete status and ETA updates rather than disappearing.
+
+For a requested PR, “ready for human review” normally means:
+
+- the issue and PR explain intent and evidence;
+- behavior, regression, invariant, and implementation-specific tests pass;
+- the relevant local CI/autocheck workflow has been reproduced when hosted CI
+  cannot run;
+- performance-sensitive work includes credible before/after evidence;
+- docs and maintained configs agree with the code;
+- stale alternatives and dead-purpose code were reviewed; and
+- the branch is clean and mergeable.
+
+After merge, remove the completed local worktree and, when its remote branch
+has been deleted, delete the local PR branch. Return the primary checkout to
+current `develop`. Stop orphaned test supervisors, but do not stop unrelated
+user services or another contributor's processes.
+
+## What This File Does Not Authorize
+
+This context does not grant permission to mutate production services,
+credentials, or unrelated work. It does not replace a requested review with
+implementation, broaden a diagnosis into a fix, or make an old conversational
+decision permanent. Use it to ask better questions and form better hypotheses,
+then verify the current contract in the repository.

--- a/cicd/coverage_record.json
+++ b/cicd/coverage_record.json
@@ -117,13 +117,15 @@
     "test_missing_stationary_seed_reparents_to_closest_shallower_contour"
   ],
   "Resuming a state with its stored random-stream position is scientifically equivalent to uninterrupted continuation under the same conditions.": [
-    "test_resume_uses_stored_key_and_matches_uninterrupted_run"
+    "test_resume_uses_stored_key_and_matches_uninterrupted_run",
+    "test_unlimited_growth_matches_preallocated_scientific_continuation"
   ],
   "A finite scientific sample limit is never exceeded, including by a partially filled replacement batch.": [
+    "test_finite_capacity_terminates_below_and_exactly_at_hard_maximum",
     "test_partial_batch_respects_non_multiple_max_samples"
   ],
   "A run that cannot satisfy its goal returns its resumable state rather than silently claiming that the goal was met.": [
-    "test_python_goal_loop_returns_after_depth_cannot_make_progress"
+    "test_python_goal_loop_reports_terminal_depth_budget_without_iteration"
   ],
   "Converting a state to results preserves every valid classic sample and excludes every unused capacity entry from user-facing sample statistics.": [
     "test_trim_keeps_log_l_blocks_aligned_to_trimmed_sample_size"

--- a/cicd/non_invariant_test_coverage.json
+++ b/cicd/non_invariant_test_coverage.json
@@ -51,6 +51,26 @@
       "path": "tests/test_core.py",
       "reason": "architecture_boundary"
     },
+    "test_compiled_depth_classifies_normal_growth_and_terminal_returns": {
+      "note": "Checks the concrete state-carried control-status representation and precedence used at compiled depth boundaries.",
+      "path": "tests/test_core.py",
+      "reason": "architecture_boundary"
+    },
+    "test_sample_storage_modes_are_explicit_and_inspectable": {
+      "note": "Checks the public finite/unlimited storage configuration and resolved physical-capacity policy.",
+      "path": "tests/test_core.py",
+      "reason": "configuration_contract"
+    },
+    "test_state_merge_applies_terminal_growth_depth_precedence": {
+      "note": "Checks the current state-merge control-status representation and precedence.",
+      "path": "tests/test_state.py",
+      "reason": "architecture_boundary"
+    },
+    "test_state_resize_grows_all_sample_buffers_and_preserves_continuation": {
+      "note": "Checks the current sample-indexed buffer schema and immutable resize wiring.",
+      "path": "tests/test_state.py",
+      "reason": "architecture_boundary"
+    },
     "test_allocation_utilities_handle_tiny_positive_volume_without_inf": {
       "note": "Checks the current allocation utility, normalization, and target construction rather than an implementation-agnostic scientific contract.",
       "path": "tests/test_allocation.py",

--- a/docs/design/REQUIREMENTS.md
+++ b/docs/design/REQUIREMENTS.md
@@ -83,8 +83,9 @@ properties that must hold independently of implementation live in
 - Requirement: The default finite maximum capacity is proportional to the root out-degree, with
   a target default of approximately one thousand samples per root lineage unless the user
   supplies a limit.
-- Requirement: The initial physical allocation is smaller than a large finite maximum and is
-  large enough for the root batch plus at least one replacement batch.
+- Requirement: The initial physical allocation is the root batch plus approximately 64
+  replacement batches, clamped to a finite maximum; it is smaller than a large finite maximum
+  so unused padding does not dominate compiled block operations.
 - Requirement: When unlimited growth is enabled and a depth epoch fills storage, the Python goal
   loop doubles physical capacity sufficiently to fit the next full replacement batch and resumes
   transparently after recompilation.

--- a/docs/design/interface/sample_storage.md
+++ b/docs/design/interface/sample_storage.md
@@ -1,0 +1,53 @@
+# Sample storage and transparent growth
+
+`NestedSampler` keeps sample-indexed arrays at a static size during each JAX
+compilation. The Python goal loop may replace that immutable storage with a
+larger copy between compiled depth calls.
+
+Finite storage is the default. If `max_samples` is omitted, its resolved value
+is `root_allocation_degree * 1000`, enlarged only when necessary to hold the
+root samples and one replacement batch. Physical storage starts at the root
+batch plus 64 replacement batches and grows geometrically to that finite
+ceiling. An explicitly smaller maximum clamps the initial allocation. The
+resolved `initial_capacity` and `max_samples` remain visible on the sampler.
+
+```python
+sampler = NestedSampler(
+    model=model,
+    max_samples=1_000_000,
+)
+print(sampler.initial_capacity, sampler.max_samples)
+```
+
+Unlimited storage requires the explicit `unlimited_samples=True` opt-in and
+cannot be combined with a finite `max_samples`. Each time storage fills, the
+Python loop normally doubles every sample-indexed buffer, recompiles for that
+new shape once, and resumes automatically. This can consume unbounded host or
+device memory, so it is not enabled by omission.
+
+```python
+sampler = NestedSampler(
+    model=model,
+    unlimited_samples=True,
+)
+```
+
+The returned `State` is the sole continuation object. Its scalar status has
+exactly one meaning after a compiled depth call:
+
+- `termination_reason != 0`: terminal; both other flags are false.
+- `needs_growth`: the same logical depth epoch can continue after resize.
+- `depth_reached`: the logical depth epoch completed normally.
+
+A growth boundary preserves `random_key`, does not increment
+`goal_loop_iter`, and does not change the allocation target. `trim()` and
+`resize()` preserve the status and key. Merging gives terminal status first,
+then a pending growth request, otherwise a normal completed-depth status.
+`NestedSamplerResults` retains only `termination_reason`; growth is transient
+orchestration state and is handled before a completed run is converted.
+
+During an interrupted epoch, `random_key` is the immediate sampling
+continuation. The internal `goal_key` retains the already-split key for the
+next logical epoch. Keeping both in `State` preserves the established random
+stream without replaying work when a physical resize divides one depth epoch
+across multiple compiled calls.

--- a/src/jaxns/core.py
+++ b/src/jaxns/core.py
@@ -31,6 +31,13 @@ from jaxns.termination_condition import (
 )
 from jaxns.types import BoolArray, FloatArray, IntArray, PRNGKey
 
+# The default finite ceiling permits substantial runs without silently opting
+# into unlimited memory. Physical storage starts smaller and grows on demand;
+# keeping both policies singular lets benchmark evidence revise either one.
+SAMPLES_PER_ROOT = 1000
+INITIAL_BATCHES = 64
+MAX_SAMPLES_REACHED = 1
+
 
 @dataclasses.dataclass(slots=True, frozen=True)
 class CoreWorkBatch(PureDataclassPytree):
@@ -490,7 +497,6 @@ class _DepthCarry(NamedTuple):
     ),
 )
 def _run_depth(
-        key: PRNGKey,
         state: State,
         sampler: AbstractSampler,
         depth_cond: TerminationCondition,
@@ -499,9 +505,14 @@ def _run_depth(
         allocation_target: str,
         root_degree: int,
         delta_K: int,
-        max_samples: int,
+        max_samples: int | None,
 ) -> State:
-    """Run one allocation depth epoch entirely in compiled JAX."""
+    """Run one allocation depth epoch entirely in compiled JAX.
+
+    The returned state atomically carries the continuation key and exactly one
+    exit outcome. A physical-capacity return may therefore be resized and
+    resumed without changing the logical allocation epoch or random stream.
+    """
 
     def build_depth_view(current_state):
         # Out-degree changes alter K_g, the expected volume path, and the
@@ -542,10 +553,15 @@ def _run_depth(
         # The user goal condition remains outside this JAX loop.
         has_gap = jnp.any(carry.plan.under_allocated(carry.relevant))
         has_buffer = (
-            carry.state.num_samples + shell_size
-            <= carry.state.samples.log_likelihoods.shape[0]
+            carry.state.num_samples
+            < carry.state.samples.log_likelihoods.shape[0]
         )
-        sample_limit = jnp.asarray(max_samples, mp_policy.count_dtype)
+        sample_limit = jnp.asarray(
+            carry.state.samples.log_likelihoods.shape[0],
+            mp_policy.count_dtype,
+        )
+        if max_samples is not None:
+            sample_limit = jnp.asarray(max_samples, mp_policy.count_dtype)
         if depth_cond.max_samples is not None:
             sample_limit = jnp.minimum(
                 sample_limit,
@@ -572,7 +588,12 @@ def _run_depth(
 
     def body(carry: _DepthCarry):
         plan_key, sample_key, next_key = jax.random.split(carry.key, 3)
-        sample_limit = jnp.asarray(max_samples, mp_policy.count_dtype)
+        sample_limit = jnp.asarray(
+            carry.state.samples.log_likelihoods.shape[0],
+            mp_policy.count_dtype,
+        )
+        if max_samples is not None:
+            sample_limit = jnp.asarray(max_samples, mp_policy.count_dtype)
         if depth_cond.max_samples is not None:
             sample_limit = jnp.minimum(
                 sample_limit,
@@ -586,7 +607,13 @@ def _run_depth(
             carry.relevant,
             shell_size,
             max_valid_lanes=(
-                sample_limit.astype(mp_policy.index_dtype)
+                jnp.minimum(
+                    sample_limit,
+                    jnp.asarray(
+                        carry.state.samples.log_likelihoods.shape[0],
+                        mp_policy.count_dtype,
+                    ),
+                ).astype(mp_policy.index_dtype)
                 - carry.state.num_samples.astype(mp_policy.index_dtype)
             ),
         )
@@ -613,16 +640,90 @@ def _run_depth(
             register=next_register,
         )
 
+    # A normal depth boundary starts the same per-depth split used before
+    # transparent growth existed. A growth resume instead uses `random_key`
+    # as the exact inner continuation after the last completed batch, while
+    # `goal_key` retains the already-derived key for the next logical epoch.
+    new_depth_key, next_goal_key = jax.random.split(state.random_key)
+    depth_key = jnp.where(
+        state.depth_reached,
+        new_depth_key,
+        state.random_key,
+    )
+    goal_key = jnp.where(
+        state.depth_reached,
+        next_goal_key,
+        state.goal_key,
+    )
     block_state, plan, relevant, register = build_depth_view(state)
+    initial_state = dataclasses.replace(
+        state,
+        random_key=depth_key,
+        goal_key=goal_key,
+        needs_growth=jnp.asarray(False, mp_policy.bool_dtype),
+        depth_reached=jnp.asarray(False, mp_policy.bool_dtype),
+    )
     initial_carry = _DepthCarry(
-        key=key,
-        state=state,
+        key=depth_key,
+        state=initial_state,
         block_state=block_state,
         plan=plan,
         relevant=relevant,
         register=register,
     )
-    return jax.lax.while_loop(cond, body, initial_carry).state
+    final_carry = jax.lax.while_loop(cond, body, initial_carry)
+
+    # Classify the single reason the compiled loop returned. Terminal reasons
+    # take precedence over a full physical buffer, while a growable buffer
+    # takes precedence over ordinary completion of the allocation/depth work.
+    scalar_cond = dataclasses.replace(
+        depth_cond,
+        dlogZ=None,
+        cummax_XL_frac=None,
+    )
+    scalar_done, scalar_reason = final_carry.register.is_done(scalar_cond)
+    hard_limit_reached = jnp.asarray(False, mp_policy.bool_dtype)
+    if max_samples is not None:
+        hard_limit_reached = final_carry.state.num_samples >= max_samples
+    termination_reason = jnp.where(
+        final_carry.state.termination_reason != 0,
+        final_carry.state.termination_reason,
+        jnp.where(
+            scalar_done,
+            scalar_reason,
+            jnp.where(
+                hard_limit_reached,
+                jnp.asarray(MAX_SAMPLES_REACHED, mp_policy.count_dtype),
+                jnp.asarray(0, mp_policy.count_dtype),
+            ),
+        ),
+    )
+    terminal = termination_reason != 0
+    has_gap = jnp.any(
+        final_carry.plan.under_allocated(final_carry.relevant)
+    )
+    storage_full = (
+        final_carry.state.num_samples
+        >= final_carry.state.samples.log_likelihoods.shape[0]
+    )
+    needs_growth = jnp.logical_and(
+        jnp.logical_not(terminal),
+        has_gap & storage_full,
+    )
+    depth_reached = jnp.logical_not(terminal | needs_growth)
+    continuation_key = jnp.where(
+        needs_growth,
+        final_carry.key,
+        goal_key,
+    )
+    return dataclasses.replace(
+        final_carry.state,
+        termination_reason=termination_reason,
+        needs_growth=needs_growth,
+        depth_reached=depth_reached,
+        random_key=continuation_key,
+        goal_key=goal_key,
+    )
 
 
 @partial(
@@ -724,7 +825,14 @@ def _sample_init_state(
 
 @dataclasses.dataclass(slots=True, frozen=True)
 class NestedSampler(PureDataclassPytree):
-    """Object-oriented configuration and Python goal-loop driver."""
+    """Object-oriented configuration and Python goal-loop driver.
+
+    Sample arrays have a static leading dimension during each compiled depth
+    call. Finite storage is the default: ``max_samples`` is a hard maximum and
+    physical buffers grow only up to it. Set ``unlimited_samples=True`` to opt
+    into unbounded geometric growth and its associated memory use and one-time
+    recompilation pause for each new shape.
+    """
 
     model: Model
     target_num_live_points: int | None = None
@@ -747,6 +855,7 @@ class NestedSampler(PureDataclassPytree):
     ] = "uniform"
     delta_K: int | None = None
     initial_capacity: int | None = None
+    unlimited_samples: bool = False
 
     def __post_init__(self):
         U_ndims = int(self.model.U_ndims(self.args, self.params))
@@ -773,10 +882,19 @@ class NestedSampler(PureDataclassPytree):
             # former half-root width on multimodal problems.
             shell_size = min(root_degree, max(1, 10 * U_ndims))
         max_samples = self.max_samples
-        if max_samples is None:
-            max_samples = max(root_degree + shell_size, 100 * root_degree)
-        if max_samples < root_degree:
-            raise ValueError("max_samples must hold all root samples.")
+        if self.unlimited_samples and max_samples is not None:
+            raise ValueError(
+                "unlimited_samples=True conflicts with a finite max_samples."
+            )
+        if not self.unlimited_samples:
+            if max_samples is None:
+                max_samples = max(
+                    root_degree + shell_size,
+                    SAMPLES_PER_ROOT * root_degree,
+                )
+            max_samples = int(max_samples)
+            if max_samples < root_degree:
+                raise ValueError("max_samples must hold all root samples.")
         delta_K = self.delta_K
         if delta_K is None:
             # One outer allocation step should normally create one full
@@ -818,25 +936,36 @@ class NestedSampler(PureDataclassPytree):
                 dlogZ=jnp.log1p(
                     jnp.asarray(1e-3, mp_policy.measure_dtype)
                 ),
-                max_samples=jnp.asarray(max_samples, mp_policy.count_dtype),
+                max_samples=(
+                    None
+                    if max_samples is None
+                    else jnp.asarray(max_samples, mp_policy.count_dtype)
+                ),
             )
-        elif termination_condition.max_samples is None:
+        elif (
+            max_samples is not None
+            and termination_condition.max_samples is None
+        ):
             termination_condition = dataclasses.replace(
                 termination_condition,
                 max_samples=jnp.asarray(max_samples, mp_policy.count_dtype),
             )
         initial_capacity = self.initial_capacity
         if initial_capacity is None:
-            initial_capacity = min(
-                max_samples + shell_size - 1,
-                max(root_degree + shell_size, root_degree + 64 * shell_size),
-            )
-        initial_capacity = max(root_degree, int(initial_capacity))
+            # Preallocating the full default maximum makes every fixed-shape
+            # block scan pay for unused padding. Start with enough room for a
+            # useful number of replacement batches, then grow geometrically.
+            initial_capacity = root_degree + INITIAL_BATCHES * shell_size
+        initial_capacity = int(initial_capacity)
+        if initial_capacity < root_degree:
+            raise ValueError("initial_capacity must hold all root samples.")
+        if max_samples is not None:
+            initial_capacity = min(initial_capacity, max_samples)
 
         object.__setattr__(self, "target_num_live_points", root_degree)
         object.__setattr__(self, "root_allocation_degree", root_degree)
         object.__setattr__(self, "shell_size", int(shell_size))
-        object.__setattr__(self, "max_samples", int(max_samples))
+        object.__setattr__(self, "max_samples", max_samples)
         object.__setattr__(self, "sampler", sampler)
         object.__setattr__(self, "termination_condition", termination_condition)
         object.__setattr__(self, "initial_capacity", initial_capacity)
@@ -857,6 +986,7 @@ class NestedSampler(PureDataclassPytree):
                 "allocation_target",
                 "delta_K",
                 "initial_capacity",
+                "unlimited_samples",
             ],
         )
 
@@ -878,7 +1008,15 @@ class NestedSampler(PureDataclassPytree):
             sample_capacity=int(self.initial_capacity),
             num_phantom=int(self.sampler.num_phantom()),
         )
-        return dataclasses.replace(state, random_key=run_key)
+        return dataclasses.replace(
+            state,
+            random_key=run_key,
+            goal_key=run_key,
+            # Initialisation is a Python goal boundary. Marking it this way
+            # makes the first compiled call perform the ordinary per-depth key
+            # split, while a capacity resume remains distinguishable.
+            depth_reached=jnp.asarray(True, mp_policy.bool_dtype),
+        )
 
     def run(self, key: PRNGKey | None = None) -> State:
         """Run until the default expectation-based goal is satisfied."""
@@ -935,26 +1073,31 @@ class NestedSampler(PureDataclassPytree):
     ) -> State:
         if depth_cond is None:
             depth_cond = self.termination_condition
-        if key is None:
-            key = state.random_key
-        if key is None:
-            key = jax.random.PRNGKey(42)
-        consecutive_no_progress = 0
-        while not bool(goal_cond(state)):
-            num_samples = int(state.num_samples)
-            capacity = state.samples.log_likelihoods.shape[0]
-            if num_samples + self.shell_size > capacity:
-                storage_capacity = self.max_samples + self.shell_size - 1
-                if capacity >= storage_capacity:
-                    break
-                new_capacity = min(
-                    storage_capacity,
-                    max(capacity * 2, num_samples + 64 * self.shell_size),
-                )
-                state = state.resize(new_capacity)
-            depth_key, key = jax.random.split(key)
-            next_state = _run_depth(
-                depth_key,
+        if key is not None:
+            state = dataclasses.replace(
+                state,
+                random_key=key,
+                goal_key=key,
+                depth_reached=jnp.asarray(True, mp_policy.bool_dtype),
+            )
+        elif state.random_key is None:
+            state = dataclasses.replace(
+                state,
+                random_key=jax.random.PRNGKey(42),
+                goal_key=jax.random.PRNGKey(42),
+                depth_reached=jnp.asarray(True, mp_policy.bool_dtype),
+            )
+        elif state.goal_key is None:
+            state = dataclasses.replace(
+                state,
+                goal_key=state.random_key,
+                depth_reached=jnp.asarray(True, mp_policy.bool_dtype),
+            )
+        while (
+            int(state.termination_reason) == 0
+            and not bool(goal_cond(state))
+        ):
+            state = _run_depth(
                 state,
                 self.sampler,
                 depth_cond,
@@ -962,39 +1105,72 @@ class NestedSampler(PureDataclassPytree):
                 allocation_target=self.allocation_target,
                 root_degree=int(self.root_allocation_degree),
                 delta_K=int(self.delta_K),
-                max_samples=int(self.max_samples),
+                max_samples=self.max_samples,
             )
-            state = dataclasses.replace(
-                next_state,
-                goal_loop_iter=next_state.goal_loop_iter + jnp.asarray(
-                    1,
-                    next_state.goal_loop_iter.dtype,
-                ),
-                random_key=key,
+            if bool(state.needs_growth):
+                capacity = state.samples.log_likelihoods.shape[0]
+                required_capacity = int(state.num_samples) + int(
+                    self.shell_size
+                )
+                new_capacity = max(2 * capacity, required_capacity)
+                if self.max_samples is not None:
+                    new_capacity = min(new_capacity, self.max_samples)
+                if new_capacity <= capacity:
+                    # This branch is defensive: the compiled classifier should
+                    # already report a finite hard maximum as terminal.
+                    state = dataclasses.replace(
+                        state,
+                        termination_reason=jnp.asarray(
+                            MAX_SAMPLES_REACHED,
+                            mp_policy.count_dtype,
+                        ),
+                        needs_growth=jnp.asarray(
+                            False,
+                            mp_policy.bool_dtype,
+                        ),
+                        depth_reached=jnp.asarray(
+                            False,
+                            mp_policy.bool_dtype,
+                        ),
+                    )
+                    break
+                # Growth resumes the same allocation target and key. Clearing
+                # only the transient request prevents this implementation
+                # boundary from becoming a logical goal iteration.
+                state = dataclasses.replace(
+                    state.resize(new_capacity),
+                    needs_growth=jnp.asarray(False, mp_policy.bool_dtype),
+                    depth_reached=jnp.asarray(False, mp_policy.bool_dtype),
+                )
+                continue
+            if int(state.termination_reason) != 0:
+                break
+            if bool(state.depth_reached):
+                state = dataclasses.replace(
+                    state,
+                    goal_loop_iter=(
+                        state.goal_loop_iter
+                        + jnp.asarray(1, state.goal_loop_iter.dtype)
+                    ),
+                )
+                continue
+            raise RuntimeError(
+                "Compiled depth returned without termination, growth, or "
+                "normal depth completion."
             )
-            if int(state.num_samples) == num_samples:
-                consecutive_no_progress += 1
-            else:
-                consecutive_no_progress = 0
-            # The paper schedule deliberately spends its first epoch exposing
-            # the root allocation before it can request work. A second empty
-            # epoch means the supplied depth condition cannot advance this
-            # state, so returning control is safer than spinning in Python.
-            if consecutive_no_progress >= 2:
-                break
-            if int(state.num_samples) >= self.max_samples:
-                break
-        done, reason = state.compute_termination_register().is_done(
-            self.termination_condition
-        )
-        return dataclasses.replace(
-            state,
-            termination_reason=jnp.where(
-                done,
-                reason,
-                state.termination_reason,
-            ),
-        )
+
+        if int(state.termination_reason) == 0:
+            done, reason = state.compute_termination_register().is_done(
+                self.termination_condition
+            )
+            if bool(done):
+                state = dataclasses.replace(
+                    state,
+                    termination_reason=reason,
+                    needs_growth=jnp.asarray(False, mp_policy.bool_dtype),
+                    depth_reached=jnp.asarray(False, mp_policy.bool_dtype),
+                )
+        return state
 
     def run_single_iteration(
             self,
@@ -1005,16 +1181,29 @@ class NestedSampler(PureDataclassPytree):
         """Run exactly one compiled depth epoch."""
         if state is None:
             state = self.initialise(key)
-            key = state.random_key
-        elif key is None:
-            key = state.random_key
-        if key is None:
-            key = jax.random.PRNGKey(42)
+        elif key is not None:
+            state = dataclasses.replace(
+                state,
+                random_key=key,
+                goal_key=key,
+                depth_reached=jnp.asarray(True, mp_policy.bool_dtype),
+            )
+        elif state.random_key is None:
+            state = dataclasses.replace(
+                state,
+                random_key=jax.random.PRNGKey(42),
+                goal_key=jax.random.PRNGKey(42),
+                depth_reached=jnp.asarray(True, mp_policy.bool_dtype),
+            )
+        elif state.goal_key is None:
+            state = dataclasses.replace(
+                state,
+                goal_key=state.random_key,
+                depth_reached=jnp.asarray(True, mp_policy.bool_dtype),
+            )
         if depth_cond is None:
             depth_cond = self.termination_condition
-        depth_key, next_key = jax.random.split(key)
-        next_state = _run_depth(
-            depth_key,
+        return _run_depth(
             state,
             self.sampler,
             depth_cond,
@@ -1022,9 +1211,8 @@ class NestedSampler(PureDataclassPytree):
             allocation_target=self.allocation_target,
             root_degree=int(self.root_allocation_degree),
             delta_K=int(self.delta_K),
-            max_samples=int(self.max_samples),
+            max_samples=self.max_samples,
         )
-        return dataclasses.replace(next_state, random_key=next_key)
 
 
 NestedSampler.register_pytree()

--- a/src/jaxns/samples.py
+++ b/src/jaxns/samples.py
@@ -156,7 +156,36 @@ def _append_samples(self: Samples, insert_idx: IntArray, parent_idxs: IntArray, 
     # Parent storage indices exist only for this scatter. The persistent child
     # records its parent likelihood contour, while the updated degree is all
     # that later race reconstruction and shrinkage require.
-    appended = self.set_slice(insert_idx, samples)
+    batch_size = samples.log_likelihoods.shape[0]
+
+    def append_full_batch(_):
+        # Preserve the single dynamic-update operation on the ordinary hot
+        # path; a general scatter would add indexing work to every batch.
+        return self.set_slice(insert_idx, samples)
+
+    def append_partial_tail(_):
+        # A finite hard maximum need not be divisible by the static replacement
+        # width. Drop out-of-range inactive lanes so the valid prefix can fill
+        # the final physical slots without an S-1 allocation beyond the limit.
+        sample_indices = insert_idx + jnp.arange(
+            batch_size,
+            dtype=mp_policy.index_dtype,
+        )
+        return jax.tree.map(
+            lambda destination, source: destination.at[sample_indices].set(
+                source,
+                mode="drop",
+            ),
+            self,
+            samples,
+        )
+
+    appended = jax.lax.cond(
+        insert_idx + batch_size <= self.log_likelihoods.shape[0],
+        append_full_batch,
+        append_partial_tail,
+        operand=None,
+    )
     out_degree = appended.out_degree.at[parent_idxs].add(
         delta_parent_out_degree
     )

--- a/src/jaxns/state.py
+++ b/src/jaxns/state.py
@@ -29,7 +29,7 @@ from jaxns.shrinkage import (
 )
 from jaxns.stats_utils import effective_sample_size_kish
 from jaxns.termination_condition import TerminationRegister
-from jaxns.types import FloatArray, IntArray
+from jaxns.types import BoolArray, FloatArray, IntArray
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
@@ -54,6 +54,15 @@ class State(PureDataclassPytree):
     )
     likelihood_order: LikelihoodOrder | None = None
     random_key: jax.Array | None = None  # [2]
+    # While growth interrupts a depth epoch, this preserves the already-split
+    # key for the next Python goal boundary.
+    goal_key: jax.Array | None = None  # [2]
+    needs_growth: BoolArray = dataclasses.field(  # []
+        default_factory=lambda: jnp.asarray(False, mp_policy.bool_dtype)
+    )
+    depth_reached: BoolArray = dataclasses.field(  # []
+        default_factory=lambda: jnp.asarray(False, mp_policy.bool_dtype)
+    )
 
     def merge(self, other: 'State') -> 'State':
         """
@@ -166,7 +175,29 @@ class State(PureDataclassPytree):
         return _trim(self)
 
     def resize(self, max_samples: int) -> "State":
-        """Return a state with larger preallocated sample buffers."""
+        """Return a state with larger sample-indexed buffers.
+
+        Control status and the continuation key are preserved. The Python
+        runner, which owns the resize boundary, clears ``needs_growth`` only
+        immediately before it resumes the interrupted depth epoch.
+
+        Args:
+            max_samples: New physical leading dimension.
+
+        Returns:
+            A state with every sample-indexed buffer grown consistently.
+
+        Raises:
+            ValueError: If ``max_samples`` would shrink existing storage.
+        """
+        current_size = self.samples.log_likelihoods.shape[0]
+        if max_samples < current_size:
+            raise ValueError(
+                "State.resize only supports growth: "
+                f"current size is {current_size}, requested {max_samples}."
+            )
+        if max_samples == current_size:
+            return self
         return dataclasses.replace(
             self,
             samples=self.samples.resize(max_samples),
@@ -373,13 +404,26 @@ def _merge(self: State, other: State) -> 'State':
     assert jax.tree.structure(self.model) == jax.tree.structure(other.model), "Cannot merge states with different models"
     assert jax.tree.structure(self.args) == jax.tree.structure(other.args), "Cannot merge states with different args"
     assert jax.tree.structure(self.params) == jax.tree.structure(other.params), "Cannot merge states with different params"
+    termination_reason = jnp.bitwise_or(
+        self.termination_reason,
+        other.termination_reason,
+    )
+    terminal = termination_reason != 0
+    needs_growth = jnp.logical_and(
+        jnp.logical_not(terminal),
+        jnp.logical_or(self.needs_growth, other.needs_growth),
+    )
+    # A merge is a completed Python-level operation. If neither input is
+    # terminal nor requesting growth, the merged continuation is at a normal
+    # depth boundary rather than an ambiguous all-false control state.
+    depth_reached = jnp.logical_not(terminal | needs_growth)
     return State(
         root_out_degree=self.root_out_degree + other.root_out_degree,
         samples=self.samples.concat(other.samples),
         num_samples=self.num_samples + other.num_samples,
         log_L_supremum=jnp.maximum(self.log_L_supremum, other.log_L_supremum),
         U_supremum=jax.tree.map(lambda x, y: jnp.where(self.log_L_supremum >= other.log_L_supremum, x, y), self.U_supremum, other.U_supremum),
-        termination_reason=jnp.where(self.termination_reason != 0, self.termination_reason, other.termination_reason),
+        termination_reason=termination_reason,
         model=self.model,
         args=self.args,
         params=self.params,
@@ -389,6 +433,9 @@ def _merge(self: State, other: State) -> 'State':
         # first use instead of pretending either input ordering is still valid.
         likelihood_order=None,
         random_key=self.random_key,
+        goal_key=self.goal_key,
+        needs_growth=needs_growth,
+        depth_reached=depth_reached,
     )
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -435,7 +435,7 @@ def test_resume_uses_stored_key_and_matches_uninterrupted_run():
         np.testing.assert_array_equal(np.asarray(left), np.asarray(right))
 
 
-def test_python_goal_loop_returns_after_depth_cannot_make_progress():
+def test_python_goal_loop_reports_terminal_depth_budget_without_iteration():
     ns = NestedSampler(
         model=make_toy_model(),
         target_num_live_points=2,
@@ -452,7 +452,196 @@ def test_python_goal_loop_returns_after_depth_cannot_make_progress():
     )
 
     assert int(state.num_samples) == 2
-    assert int(state.goal_loop_iter) == 2
+    assert int(state.goal_loop_iter) == 0
+    assert int(state.termination_reason) == core.MAX_SAMPLES_REACHED
+    assert not bool(state.needs_growth)
+    assert not bool(state.depth_reached)
+
+
+def test_sample_storage_modes_are_explicit_and_inspectable():
+    finite_default = NestedSampler(
+        model=make_toy_model(),
+        target_num_live_points=2,
+        shell_size=1,
+        sampler=DeterministicSampler(),
+    )
+    assert finite_default.max_samples == 2 * core.SAMPLES_PER_ROOT
+    assert finite_default.initial_capacity == 2 + core.INITIAL_BATCHES
+    assert not finite_default.unlimited_samples
+
+    finite_large = NestedSampler(
+        model=make_toy_model(),
+        target_num_live_points=2,
+        shell_size=1,
+        max_samples=5000,
+        sampler=DeterministicSampler(),
+    )
+    assert finite_large.max_samples == 5000
+    assert finite_large.initial_capacity == 2 + core.INITIAL_BATCHES
+
+    unlimited = NestedSampler(
+        model=make_toy_model(),
+        target_num_live_points=2,
+        shell_size=1,
+        unlimited_samples=True,
+        sampler=DeterministicSampler(),
+    )
+    assert unlimited.max_samples is None
+    assert unlimited.initial_capacity == 2 + core.INITIAL_BATCHES
+
+    with pytest.raises(ValueError, match="conflicts"):
+        NestedSampler(
+            model=make_toy_model(),
+            max_samples=100,
+            unlimited_samples=True,
+        )
+
+
+def _assert_single_depth_outcome(state):
+    outcomes = (
+        int(state.termination_reason) != 0,
+        bool(state.needs_growth),
+        bool(state.depth_reached),
+    )
+    assert sum(outcomes) == 1
+
+
+def test_compiled_depth_classifies_normal_growth_and_terminal_returns():
+    common = {
+        "model": make_toy_model(),
+        "target_num_live_points": 2,
+        "shell_size": 1,
+        "delta_K": 1,
+        "sampler": DeterministicSampler(),
+    }
+    normal_sampler = NestedSampler(
+        max_samples=4,
+        initial_capacity=4,
+        **common,
+    )
+    normal_state = normal_sampler.initialise(jax.random.PRNGKey(31))
+    _, normal_goal_key = jax.random.split(normal_state.random_key)
+    normal = normal_sampler.run_single_iteration(
+        normal_state,
+        depth_cond=TerminationCondition(dlogZ=jnp.asarray(1.1)),
+    )
+    _assert_single_depth_outcome(normal)
+    assert bool(normal.depth_reached)
+    np.testing.assert_array_equal(normal.random_key, normal_goal_key)
+
+    growth_sampler = NestedSampler(
+        unlimited_samples=True,
+        initial_capacity=2,
+        termination_condition=TerminationCondition(),
+        **common,
+    )
+    growth_state = dataclasses.replace(
+        growth_sampler.initialise(jax.random.PRNGKey(32)),
+        goal_loop_iter=jnp.asarray(1, dtype=jnp.int32),
+    )
+    growth_depth_key, growth_goal_key = jax.random.split(
+        growth_state.random_key
+    )
+    growth = growth_sampler.run_single_iteration(
+        growth_state,
+        depth_cond=TerminationCondition(dlogZ=jnp.asarray(0.5)),
+    )
+    _assert_single_depth_outcome(growth)
+    assert bool(growth.needs_growth)
+    assert int(growth.goal_loop_iter) == 1
+    np.testing.assert_array_equal(growth.random_key, growth_depth_key)
+    np.testing.assert_array_equal(growth.goal_key, growth_goal_key)
+
+    terminal_sampler = NestedSampler(
+        max_samples=2,
+        initial_capacity=2,
+        **common,
+    )
+    terminal_state = dataclasses.replace(
+        terminal_sampler.initialise(jax.random.PRNGKey(33)),
+        goal_loop_iter=jnp.asarray(1, dtype=jnp.int32),
+    )
+    terminal = terminal_sampler.run_single_iteration(terminal_state)
+    _assert_single_depth_outcome(terminal)
+    assert int(terminal.termination_reason) == core.MAX_SAMPLES_REACHED
+    assert int(terminal.goal_loop_iter) == 1
+
+
+def test_unlimited_growth_matches_preallocated_scientific_continuation():
+    common = {
+        "model": make_toy_model(),
+        "target_num_live_points": 2,
+        "shell_size": 1,
+        "delta_K": 1,
+        "unlimited_samples": True,
+        "sampler": DeterministicSampler(),
+        "termination_condition": TerminationCondition(),
+    }
+    tiny = NestedSampler(initial_capacity=2, **common)
+    preallocated = NestedSampler(initial_capacity=32, **common)
+
+    def goal(state):
+        return int(state.goal_loop_iter) >= 2
+
+    key = jax.random.PRNGKey(34)
+
+    depth_cond = TerminationCondition(dlogZ=jnp.asarray(0.5))
+    grown = tiny.run_until_goal(goal, depth_cond=depth_cond, key=key)
+    reference = preallocated.run_until_goal(
+        goal,
+        depth_cond=depth_cond,
+        key=key,
+    )
+
+    # Capacity 2 -> 4 -> 8 proves that more than one shape boundary was
+    # crossed. The valid scientific prefix and continuation state must remain
+    # independent of those implementation-only boundaries.
+    assert grown.samples.log_likelihoods.shape[0] == 8
+    assert reference.samples.log_likelihoods.shape[0] == 32
+    assert int(grown.goal_loop_iter) == int(reference.goal_loop_iter) == 2
+    assert int(grown.num_samples) == int(reference.num_samples) == 5
+    grown = grown.trim()
+    reference = reference.trim()
+    for left, right in zip(
+        jax.tree.leaves(grown),
+        jax.tree.leaves(reference),
+        strict=True,
+    ):
+        np.testing.assert_array_equal(np.asarray(left), np.asarray(right))
+
+
+def test_finite_capacity_terminates_below_and_exactly_at_hard_maximum():
+    common = {
+        "model": make_toy_model(),
+        "target_num_live_points": 2,
+        "shell_size": 2,
+        "delta_K": 2,
+        "max_samples": 5,
+        "sampler": DeterministicSampler(),
+    }
+    below = NestedSampler(initial_capacity=5, **common).run_until_goal(
+        lambda state: False,
+        depth_cond=TerminationCondition(max_samples=3),
+        key=jax.random.PRNGKey(35),
+    )
+    assert int(below.num_samples) == 3
+    assert below.samples.log_likelihoods.shape[0] == 5
+    assert int(below.termination_reason) == core.MAX_SAMPLES_REACHED
+    _assert_single_depth_outcome(below)
+
+    exact = NestedSampler(initial_capacity=3, **common).run_until_goal(
+        lambda state: False,
+        depth_cond=TerminationCondition(),
+        key=jax.random.PRNGKey(36),
+    )
+    assert int(exact.num_samples) == 5
+    assert exact.samples.log_likelihoods.shape[0] == 5
+    assert int(exact.termination_reason) == core.MAX_SAMPLES_REACHED
+    _assert_single_depth_outcome(exact)
+    assert (
+        int(exact.to_result().termination_reason)
+        == core.MAX_SAMPLES_REACHED
+    )
 
 
 def test_state_checkpoint_round_trip_preserves_resume_key_and_order():

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 import numpy as np
 import pytest
 from jax import numpy as jnp
@@ -7,7 +9,7 @@ from tensorflow_probability.substrates import jax as tfp
 
 from jaxns.core import NestedSampler
 from jaxns.model import Model
-from jaxns.race_tree import build_block_state
+from jaxns.race_tree import build_block_state, initialise_likelihood_order
 from jaxns.samples import PhantomSamples, Samples
 from jaxns.shrinkage import (
     classic_dirichlet_concentrations,
@@ -183,6 +185,82 @@ def test_samples_resize_preserves_constraints_and_provenance_fields():
         np.asarray(resized.out_degree[2:]),
         np.array([0, 0], dtype=np.int32),
     )
+
+
+def test_state_resize_grows_all_sample_buffers_and_preserves_continuation():
+    state = _make_strict_contour_violation_state()
+    order = initialise_likelihood_order(
+        state.samples.log_likelihoods,
+        state.num_samples,
+    )
+    key = random.PRNGKey(91)
+    state = dataclasses.replace(
+        state,
+        likelihood_order=order,
+        random_key=key,
+        goal_key=key,
+        needs_growth=jnp.asarray(True),
+    )
+
+    resized = state.resize(4)
+
+    assert resized.samples.log_likelihoods.shape == (4,)
+    assert resized.samples.log_L_constraints.shape == (4,)
+    assert resized.samples.U_samples.shape == (4, 1)
+    assert resized.samples.out_degree.shape == (4,)
+    assert resized.samples.num_likelihood_evaluations.shape == (4,)
+    assert resized.samples.phantom_samples.valid_mask.shape == (4, 0)
+    assert resized.samples.phantom_samples.log_L.shape == (4, 0)
+    assert resized.samples.phantom_samples.U_samples.shape == (4, 0, 1)
+    assert resized.likelihood_order.sample_indices.shape == (4,)
+    np.testing.assert_array_equal(np.asarray(resized.random_key), key)
+    np.testing.assert_array_equal(np.asarray(resized.goal_key), key)
+    assert bool(resized.needs_growth)
+    assert not bool(resized.depth_reached)
+    assert int(resized.termination_reason) == 0
+
+    trimmed = resized.trim()
+    assert trimmed.samples.log_likelihoods.shape == (1,)
+    assert trimmed.likelihood_order.sample_indices.shape == (1,)
+    np.testing.assert_array_equal(np.asarray(trimmed.random_key), key)
+    np.testing.assert_array_equal(np.asarray(trimmed.goal_key), key)
+    assert bool(trimmed.needs_growth)
+
+    with pytest.raises(ValueError, match="only supports growth"):
+        resized.resize(3)
+
+
+def test_state_merge_applies_terminal_growth_depth_precedence():
+    base = dataclasses.replace(
+        _make_strict_contour_violation_state(),
+        random_key=random.PRNGKey(92),
+    )
+    terminal = dataclasses.replace(
+        base,
+        termination_reason=jnp.asarray(2, dtype=jnp.int32),
+        needs_growth=jnp.asarray(True),
+        depth_reached=jnp.asarray(True),
+    )
+    growth = dataclasses.replace(
+        base,
+        needs_growth=jnp.asarray(True),
+        depth_reached=jnp.asarray(False),
+    )
+
+    merged_terminal = terminal.merge(growth)
+    assert int(merged_terminal.termination_reason) == 2
+    assert not bool(merged_terminal.needs_growth)
+    assert not bool(merged_terminal.depth_reached)
+
+    completed = dataclasses.replace(
+        base,
+        needs_growth=jnp.asarray(False),
+        depth_reached=jnp.asarray(True),
+    )
+    merged_growth = growth.merge(completed)
+    assert int(merged_growth.termination_reason) == 0
+    assert bool(merged_growth.needs_growth)
+    assert not bool(merged_growth.depth_reached)
 
 
 def test_state_consistency_rejects_strict_contour_violation():


### PR DESCRIPTION
Closes #250.

## Intent

Keep fixed-shape arrays inside each compiled depth call while making physical
capacity an orchestration concern. A full buffer now returns an immutable
`State` to the Python goal loop, which grows every sample-indexed buffer and
resumes the same logical depth epoch without advancing the user's goal
iteration or changing the scientific random stream.

## What changed

- finite storage remains the default; omitted `max_samples` resolves to
  approximately `1000 * root_out_degree` and remains the hard scientific
  ceiling;
- `unlimited_samples=True` is an explicit, mutually exclusive opt-in to
  unbounded geometric growth;
- initial physical allocation is the root batch plus 64 replacement batches,
  clamped to the finite maximum, instead of eagerly allocating the ceiling;
- `State` alone carries `needs_growth`, `depth_reached`, the termination reason,
  and both immediate-continuation and next-goal random keys;
- terminal, growth, and normal-depth outcomes have explicit precedence;
- partial replacement batches fill a non-divisible finite tail exactly without
  allocating `S - 1` entries beyond the hard maximum;
- growth preserves the allocation target and does not increment
  `goal_loop_iter`; only a completed logical depth epoch increments it;
- resize, trim, merge, checkpoint/resume, and result conversion semantics are
  covered and documented;
- contributor guidance now includes the shared `COMMON_CONTEXT.md` orientation
  and dedicated-worktree rules ported from `bx_trading` and adapted to JAXNS.

## Correctness evidence

All commands ran locally on the same CPU development environment.

| Evidence | Result |
|---|---:|
| `conda run -n jaxns_py pytest -q tests` | **206 passed** in 859.29 s |
| Standard-problem matrix | **20/20 passed**, all ten problems with phantom collection off and on, unchanged tolerances |
| `pytest -q cicd/reviewer_autochecks cicd/system_tests` | **5 passed** |
| Ruff on all touched Python files | **passed** |
| `git diff --check` | **passed** |

The new deterministic continuation regression forces capacity changes
`2 -> 4 -> 8` and compares the trimmed result leaf-for-leaf with a run
preallocated to 32. Every scientific sample, ordering field, counter, status,
and continuation key is exactly equal. Separate tests cover limits below and
exactly on a non-batch-aligned finite maximum, all sample/phantom/order buffers,
and terminal > growth > normal-depth precedence.

## Performance and code-intent evidence

I ran the performance-and-intent review against the JAX execution boundary.
The common full-batch append still uses one dynamic-update operation and
replacement sampling remains vmapped. Only the rare partial finite tail uses a
scatter. Resizing and recompilation remain exclusively in the Python goal loop.

An initial prototype eagerly allocated the full default `1000 * d0` ceiling.
Same-machine A/B measurements showed why that should not ship:

| Standard problem | develop | eager full ceiling | Change |
|---|---:|---:|---:|
| basic wall time | 22.39 s | 24.44 s | +9% |
| basic peak RSS | 561,520 KiB | 584,608 KiB | +4% |
| 8D MVN wall time | 32.19 s | 55.82 s | +73% |
| 8D MVN peak RSS | 1,060,976 KiB | 1,223,232 KiB | +15% |

The final root-plus-64-batches policy reduced that 8D prototype run to 41.83 s
and 1,187,036 KiB while retaining the much larger finite ceiling. The remaining
comparison with `develop` is not like-for-like work: `develop` stops at its old
5,360-entry physical boundary, whereas this branch transparently grows and
continues to 6,007 valid samples under the same goal. That behavior difference
is the bug fixed here, so the shorter old time is not evidence of a faster
equivalent run.

The intended trade-off is explicit: growth may cause a one-time recompilation
pause at a new shape, while ordinary compiled iterations avoid scanning a huge
unused leading dimension. No sampling serialization, extra sort, or steady-path
Python callback was introduced.
