### PR TITLE
Bound final evidence Monte Carlo memory

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[tests]
+          # This maintained demo is the base scientific workflow. Installing
+          # test extras here would hide an undeclared runtime dependency.
+          python -m pip install .
 
       - name: Run demos in directory order
         run: |

--- a/benchmarks/issue_249/README.md
+++ b/benchmarks/issue_249/README.md
@@ -1,0 +1,27 @@
+# Bounded final-MC benchmark
+
+`run_bounded_mc.py` uses the issue-247 scientific configuration and measures
+the final phantom-conditioned 1,000-draw calculation after the nested-sampling
+state and result are ready. The first timing includes lowering and compilation;
+later timings reuse the executable. RSS immediately before final MC and the
+process peak are reported separately.
+
+Run one batch-size point with this worktree first on `PYTHONPATH`:
+
+```bash
+conda run -n jaxns_py env \
+  PYTHONPATH=/tmp/jaxns-issue-249/src \
+  MPLCONFIGDIR=/tmp/matplotlib-issue249 \
+  python benchmarks/issue_249/run_bounded_mc.py \
+  --case basic_mvn --batch-size 128
+```
+
+The maintained comparison covers `basic_mvn`, `spike_slab`, and
+`spike_slab10`, with 1,000 draws and the same random key for every batch size.
+Add `--inspect-program` to report compiler argument, output, alias, and
+temporary-memory estimates together with small structural HLO counts. The
+compiler report is secondary evidence: measured wall time and process peak RSS
+remain the acceptance measurements.
+
+The accepted measurements and interpretation are recorded in
+[`REPORT.md`](REPORT.md).

--- a/benchmarks/issue_249/REPORT.md
+++ b/benchmarks/issue_249/REPORT.md
@@ -1,0 +1,125 @@
+# Issue 249 bounded final-MC report
+
+## Decision
+
+Use the 64-draw economical streaming program as the default final-evidence
+path. It materially lowers measured and compiler-reported memory on every
+required production problem, preserves the statistical model, and is faster
+in steady execution. The one-time compile-and-first call is also faster on two
+problems and 4% slower on one, despite the larger bounded-control program.
+
+This report compares this branch with its exact parent, develop commit
+`cb17efc`, rather than with a historical package. Both sources use Python
+3.12.9, JAX/JAXLIB 0.10.0, CPU float64, seed 0, 1,000 final evidence draws,
+30 root chains per dimension, replacement width 10 per dimension, five
+isotropic perfect-slice transitions per dimension, and the same completed
+nested-sampling state for each problem. Every reported source record verified
+its imported module path. The first timing includes lowering, compilation, and
+execution; steady timing is the median of five synchronized repetitions, with
+the interquartile range shown.
+
+## Production measurements
+
+| problem | source | blocks | phantoms | first s | steady median [IQR] s | peak RSS MiB | mean log Z |
+|---|---|---:|---:|---:|---:|---:|---:|
+| basic MVN | develop | 6,049 | 47,104 | 8.739 | 6.432 [6.330, 6.733] | 3,018.9 | -24.18646 |
+| basic MVN | bounded 64 | 6,049 | 47,104 | 7.095 | 4.483 [4.399, 5.394] | 825.1 | -24.19262 |
+| spike-slab 8D | develop | 5,898 | 45,880 | 9.389 | 5.961 [5.946, 5.973] | 2,986.1 | -18.49912 |
+| spike-slab 8D | bounded 64 | 5,898 | 45,880 | 6.337 | 4.064 [3.853, 4.167] | 840.3 | -18.48513 |
+| spike-slab 10D | develop | 7,862 | 76,610 | 11.499 | 8.752 [8.708, 8.914] | 4,277.3 | -22.98789 |
+| spike-slab 10D | bounded 64 | 7,862 | 76,610 | 8.519 | 5.661 [5.604, 5.737] | 990.3 | -22.98211 |
+
+Peak RSS falls by 72.7%, 71.9%, and 76.8% respectively. Median steady runtime
+improves by 30.3%, 31.8%, and 35.3%. Compile-and-first improves by 18.8%,
+32.5%, and 25.9%. The paired mean-log-evidence differences are 0.0140 or
+smaller and are far below the run-level uncertainties; formal
+distributional tests compare independently keyed ensembles at explicit Monte
+Carlo tolerances.
+
+The final basic-MVN batch sweep showed the intended trade-off: batch sizes 32,
+64, 128, and 256 reached about 741, 817, 966, and 1,272 MiB peak RSS. Batch 64
+had the best measured knee at 4.53 seconds steady; 32 saved another 76 MiB but
+took 4.75 seconds, while 128 and 256 took 4.77 and 5.90 seconds. A 512-draw
+prototype reached about 1,871 MiB. Wall-time measurements were collected on a
+shared CPU and are therefore interpreted together with compiler memory and
+the large RSS deltas, not in isolation.
+
+Classic-only MC was checked separately because it was already inexpensive.
+On the same basic-MVN state, develop's five-run steady median was 0.860 seconds
+[IQR 0.693, 1.394] with 1,157.4 MiB process peak; bounded 64 took 0.523
+seconds [0.485, 0.534] with 664.0 MiB peak. Its compile-and-first time improved
+from 4.272 to 2.354 seconds. Thus the selected default does not trade the
+phantom improvement for a classic-only regression.
+
+## Compiler and execution-plan evidence
+
+For the 6,049-block basic-MVN program, XLA's CPU memory analysis reports:
+
+| source | argument MiB | output MiB | temporary MiB | HLO bytes | sorts | scatters | whiles |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| develop | 0.66 | 277.68 | 2,055.77 | 163,813 | 1 | 14 | 11 |
+| bounded 64 | 0.66 | 0.78 | 151.60 | 188,027 | 1 | 14 | 13 |
+
+The output estimate falls by 99.7% because the default no longer returns six
+unrequested draw-by-block diagnostic matrices. Temporary memory falls by
+92.6% because the scan keeps only one vmapped MC batch live and carries only
+the online block sufficient statistics between batches. Deterministic
+sparse-event sorting and Kish preparation remain outside that scan, evidenced
+by the unchanged single sort. The two additional while calls are the bounded
+scan/control structure and explain the larger HLO. Their one-time compilation
+effect is measured rather than inferred from HLO size. Replacement sampling in
+the nested-sampling depth loop remains fully vmapped and is not changed by
+this final-inference scan.
+
+## Statistical and contract evidence
+
+- Fixed-key calls are deterministic for each specialization. If a batch is at
+  least the requested draw count, the result is bit-for-bit the old single
+  batch for that key.
+- Batched and unbatched independently keyed ensembles agree in evidence and
+  block-probability moments at explicit Monte Carlo tolerances.
+- A final partial batch is weighted by its actual draw count when sufficient
+  statistics are merged.
+- Tests cover batch size one, a partial batch, a batch no smaller than the
+  ensemble, invalid sizes, classic no-phantom mode, singleton two-class
+  blocks, plateau three-class blocks, and Kish gating both active and inactive.
+- The unchanged standard-problem release gate passes all 20 phantom-off/on
+  cases. The existing 30-seed-per-row v2/current accuracy matrix remains in
+  `benchmarks/issue_247/REPORT.md`; this change alters only how draws from that
+  same final shrinkage model are streamed.
+- The final repository suite passes 224 tests in 487.41 seconds; reviewer
+  autochecks, focused Ruff, and flake8 syntax/undefined-name checks also pass.
+
+Full per-draw/per-block diagnostics remain opt-in with `diagnostics=True`.
+Those arrays have an unavoidable output-memory floor proportional to draws
+times blocks, which the API and docstrings state explicitly.
+
+## Performance and intent review
+
+The required review found and fixed two material issues before acceptance:
+
+1. The first compiled scan emitted one `[G]` sufficient-statistic vector per
+   batch and reduced them afterwards. Although small at four batches, this
+   would asymptotically recreate an `[M, G]` intermediate for batch size one.
+   The final scan instead carries five online `[G]` accumulators and emits only
+   the required `[M]` evidence and entropy ensembles.
+2. The provisional 256-draw default was dominated after that correction.
+   Representative 32/64/128/256 measurements selected 64 as the runtime and
+   memory knee.
+
+No unresolved correctness or hot-path performance finding remains. At the
+execution-layer boundary, the deterministic sparse event plan is prepared once
+per compiled call, one `vmap` samples independent draws within a batch, and one
+device `scan` serializes batches. This does not introduce `lax.map` or alter the
+fully vmapped replacement sampler in the depth loop. Draw count and batch size
+remain static specialization inputs, as they determine compiled shapes and
+loop trip count; scientific arrays and the frozen, slotted event pytree remain
+dynamic children rather than large static constants.
+
+Residual risks are explicit: requesting full diagnostics necessarily retains
+the draw-by-block output; changing draw count or batch size may compile a new
+specialization; and the measurements cover CPU rather than accelerator
+backends. The benchmark runner records source path, versions, platform, device,
+precision, production shapes, first-call time, repeated synchronized time,
+process RSS, and optional compiler memory/HLO structure so those risks can be
+remeasured.

--- a/benchmarks/issue_249/run_bounded_mc.py
+++ b/benchmarks/issue_249/run_bounded_mc.py
@@ -1,0 +1,184 @@
+"""Measure final evidence sampling independently from the nested-sampling run."""
+
+import argparse
+import importlib.metadata
+import json
+import os
+import platform
+import re
+import resource
+import sys
+import time
+from pathlib import Path
+
+import psutil
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import jax
+
+import jaxns
+from jaxns.constrained_sampler import UniDimSliceSampler
+from jaxns.core import NestedSampler
+from jaxns.results import _block_state_from_results
+from tests.test_ns_standard_problems import STANDARD_PROBLEM_CASES_BY_NAME
+
+
+def _compiled_program_record(results, *, key, draws, batch_size):
+    """Inspect the exact final-MC executable used by the selected source."""
+    from jaxns import phantom_eval
+
+    block_state = _block_state_from_results(results)
+    if hasattr(phantom_eval, "_sample_mc_shrinkage_summary_jit"):
+        lowered = phantom_eval._sample_mc_shrinkage_summary_jit.lower(
+            key=key,
+            log_L_constraints=results.log_L_constraints,
+            log_L_classic=results.log_L,
+            K_classic=results.num_live_points_per_sample,
+            valid_phantom=results.valid_phantom,
+            log_L_phantom=results.log_L_phantom,
+            num_samples=results.total_num_samples,
+            num_Z_samples=draws,
+            block_state=block_state,
+            batch_size=min(batch_size, draws),
+            C_min=20,
+        )
+        program = "bounded-summary"
+    else:
+        # Develop before issue 249 has one monolithic full-diagnostic program;
+        # its public batch argument is present but not used by the kernel.
+        from jaxns.results import _sample_mc_shrinkage_with_block_state_jit
+
+        lowered = _sample_mc_shrinkage_with_block_state_jit.lower(
+            key=key,
+            log_L_constraints=results.log_L_constraints,
+            log_L_classic=results.log_L,
+            K_classic=results.num_live_points_per_sample,
+            valid_phantom=results.valid_phantom,
+            log_L_phantom=results.log_L_phantom,
+            total_num_samples=results.total_num_samples,
+            num_Z_samples=draws,
+            block_state=block_state,
+            batch_size=batch_size,
+            C_min=20,
+        )
+        program = "monolithic-diagnostics"
+    compiled = lowered.compile()
+    memory = compiled.memory_analysis()
+    hlo = lowered.compiler_ir(dialect="hlo").as_hlo_text()
+    return {
+        "compiled_program": program,
+        "compiled_argument_mib": memory.argument_size_in_bytes / 1024 ** 2,
+        "compiled_output_mib": memory.output_size_in_bytes / 1024 ** 2,
+        "compiled_temporary_mib": memory.temp_size_in_bytes / 1024 ** 2,
+        "compiled_alias_mib": memory.alias_size_in_bytes / 1024 ** 2,
+        "hlo_text_bytes": len(hlo.encode("utf-8")),
+        "hlo_while_calls": len(re.findall(r"\bwhile\(", hlo)),
+        "hlo_sort_calls": len(re.findall(r"\bsort\(", hlo)),
+        "hlo_scatter_calls": len(re.findall(r"\bscatter\(", hlo)),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--case", required=True)
+    parser.add_argument(
+        "--conditioning",
+        choices=("classic", "phantom"),
+        default="phantom",
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--draws", type=int, default=1000)
+    parser.add_argument("--batch-size", type=int, required=True)
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--source-id", default="working-tree")
+    parser.add_argument("--inspect-program", action="store_true")
+    args = parser.parse_args()
+
+    case = STANDARD_PROBLEM_CASES_BY_NAME[args.case]
+    model, truth = case.build_case()
+    ndims = int(model.U_ndims())
+    root_degree = 30 * ndims
+    replacement_width = min(root_degree, 10 * ndims)
+    num_slices = 5 * ndims
+    sampler = UniDimSliceSampler(
+        model=model,
+        num_slices=num_slices,
+        no_step_out=True,
+        gradient_guided=False,
+        collect_phantom_samples=True,
+        phantom_burn_in=num_slices - 1 - ndims,
+    )
+    nested_sampler = NestedSampler(
+        model=model,
+        root_allocation_degree=root_degree,
+        shell_size=replacement_width,
+        max_samples=100 * root_degree,
+        collect_phantom_samples=True,
+        sampler=sampler,
+    )
+    state = nested_sampler.run(jax.random.PRNGKey(args.seed))
+    jax.block_until_ready(state)
+    results = state.to_result().trim()
+    jax.block_until_ready(results)
+
+    process = psutil.Process()
+    rss_before_mc = process.memory_info().rss
+    key = jax.random.fold_in(jax.random.PRNGKey(args.seed), 1)
+    durations = []
+    log_Z_means = []
+    for _ in range(args.repetitions):
+        start = time.perf_counter()
+        samples = results.sample_evidence_mc(
+            num_samples=args.draws,
+            conditioning=args.conditioning,
+            key=key,
+            batch_size=args.batch_size,
+        )
+        jax.block_until_ready(samples)
+        durations.append(time.perf_counter() - start)
+        log_Z_means.append(float(samples.log_Z_mean))
+
+    record = {
+        "source_id": args.source_id,
+        "case": args.case,
+        "conditioning": args.conditioning,
+        "seed": args.seed,
+        "draws": args.draws,
+        "batch_size": args.batch_size,
+        "compile_and_first_s": durations[0],
+        "steady_s": durations[1:],
+        "rss_before_mc_mib": rss_before_mc / 1024 ** 2,
+        "process_peak_rss_mib": (
+            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        ),
+        "log_Z_means": log_Z_means,
+        "truth_log_Z": float(truth),
+        "classic_samples": int(results.total_num_samples),
+        "phantom_samples": int(results.total_phantom_samples),
+        "num_blocks": int(samples.log_L_blocks.shape[0]),
+        "full_diagnostics": samples.p_gt_samples is not None,
+        "jaxns_module": os.path.realpath(jaxns.__file__),
+        "jaxns_version": importlib.metadata.version("jaxns"),
+        "jax_version": jax.__version__,
+        "jaxlib_version": jax.lib.__version__,
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "device": str(jax.devices()[0]),
+        "x64": bool(jax.config.jax_enable_x64),
+    }
+    if args.inspect_program:
+        record.update(
+            _compiled_program_record(
+                results,
+                key=key,
+                draws=args.draws,
+                batch_size=args.batch_size,
+            )
+        )
+    print(json.dumps(record, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/cicd/coverage_record.json
+++ b/cicd/coverage_record.json
@@ -72,6 +72,11 @@
   "Dependence within a phantom cluster is preserved by sharing one random cluster weight across all observations and all blocks contributed by that cluster in one shrinkage draw.": [
     "test_deterministic_gamma_helper_reuses_cluster_weights_across_blocks_and_components"
   ],
+  "Changing how independent final Monte Carlo draws are batched does not change phantom-cluster identity, the joint shrinkage law, or the evidence distribution.": [
+    "test_sample_evidence_mc_batching_is_reproducible_and_matches_moments",
+    "test_sample_evidence_mc_one_batch_preserves_fixed_key_draws",
+    "test_batched_summary_preserves_block_models_and_kish_gate"
+  ],
   "A phantom contributes to a block only when its cluster parent contour is no stricter than the preceding block contour and the phantom lies beyond that preceding contour.": [
     "test_per_cluster_counts_are_parent_contour_gated_with_equality_and_open_interval",
     "test_reference_count_matrices_expose_parent_gated_R_and_aggregates"
@@ -145,7 +150,11 @@
     "test_count_matrix_validation_rejects_malformed_count_relations",
     "test_count_input_validation_rejects_stale_and_malformed_metadata",
     "test_results_sample_mc_shrinkage_rejects_malformed_arrays_before_jit",
-    "test_public_sample_mc_shrinkage_rejects_stale_block_likelihoods_before_jit"
+    "test_public_sample_mc_shrinkage_rejects_stale_block_likelihoods_before_jit",
+    "test_sample_evidence_mc_rejects_invalid_batch_sizes"
+  ],
+  "Importing and using the non-plotting scientific API does not require plotting dependencies, while requesting an unavailable optional feature fails with an actionable installation remedy.": [
+    "test_missing_plotting_dependency_has_actionable_error"
   ],
   "Numerically stable evidence arithmetic represents values across the supported likelihood dynamic range without converting avoidable underflow or overflow into finite scientific conclusions.": [
     "test_log_space",

--- a/cicd/non_invariant_test_coverage.json
+++ b/cicd/non_invariant_test_coverage.json
@@ -1,6 +1,26 @@
 {
   "schema_version": 1,
   "tests": {
+    "test_dependency_metadata_matches_feature_boundaries": {
+      "note": "Checks the current packaging classification and optional-extra metadata rather than an implementation-agnostic scientific contract.",
+      "path": "tests/test_optional_dependencies.py",
+      "reason": "packaging_boundary"
+    },
+    "test_full_diagnostics_support_a_partial_final_batch": {
+      "note": "Checks the opt-in full-diagnostic output schema over a partial final batch.",
+      "path": "tests/test_phantom_results.py",
+      "reason": "architecture_boundary"
+    },
+    "test_legacy_sample_evidence_uses_the_bounded_default": {
+      "note": "Checks that the legacy evidence convenience method shares the bounded default.",
+      "path": "tests/test_phantom_results.py",
+      "reason": "architecture_boundary"
+    },
+    "test_sample_evidence_mc_batches_have_exact_requested_shape": {
+      "note": "Checks the current bounded-batch result schema and batch-size edge cases.",
+      "path": "tests/test_phantom_results.py",
+      "reason": "architecture_boundary"
+    },
     "test_bruteforce_utilities_preserve_model_unit_dtypes": {
       "note": "Checks compatibility between the regular-grid diagnostic utilities and jaxctx's per-prior U-space dtype validation.",
       "path": "tests/test_utils.py",

--- a/docs/design/DEPENDENCIES.md
+++ b/docs/design/DEPENDENCIES.md
@@ -1,0 +1,96 @@
+# Dependency Decisions
+
+This audit records why each install requirement exists and which public
+operation consumes it. The source of truth for package metadata remains
+`pyproject.toml`.
+
+## Runtime classifications
+
+| Dependency | Classification | Decision and evidence |
+|---|---|---|
+| `jax` | Core runtime | Keep in base. Every sampler, state, result, pytree, and numerical path uses JAX. JAX also selects a compatible `jaxlib`, NumPy, and SciPy. |
+| `jaxlib` | Transitive JAX runtime | Remove the independent declaration. Directly constraining it duplicates JAX metadata and can interfere with accelerator-specific JAX installations. |
+| `jaxctx` | Public modeling API | Keep in base. `Model`, state, result, and type APIs carry `CtxParams`; the documented prior workflow uses JAXCTX transforms and priors. |
+| `numpy` | Core and host validation | Keep in base. Public validation, result summaries, serialization helpers, and reference calculations use NumPy directly. |
+| `scipy` | Public diagnostics | Keep in base. Corner diagnostics use `scipy.stats.gaussian_kde` and `insert_index_diagnostic` uses `scipy.stats.kstwobign`; JAX also requires SciPy. Moving it would not produce a genuinely SciPy-free core install. |
+| `tfp-nightly` | Public model authoring | Keep in base. The README, installation demo, standard problems, and JAXCTX `Prior` implementation use TensorFlow Probability JAX distributions. JAXCTX 1.1.5 imports TFP for its public prior module but does not declare that dependency itself, so JAXNS must supply it for the documented workflow. |
+| `matplotlib` | Plotting | Move to `plotting`. Scientific result imports and local runs do not need it. Plotting entry points import it lazily and explain how to install `jaxns[plotting]` when absent. |
+| `zmq` | Unimplemented distributed execution | Remove. There is no `jaxns.fabric` package in this release, so the old dependency and console entry points described functionality that cannot run. A `distributed` extra will be introduced only after the tracked design validation and implementation exist; the eventual package would be `pyzmq`, not the stale `zmq` name. |
+
+## Extras
+
+- `plotting`: Matplotlib and only the dependency needed by result and
+  ellipsoid plotting entry points.
+- `examples`: Matplotlib, scikit-learn, and Optax, matching the maintained
+  notebook and example feature set. Base modeling dependencies are inherited
+  from JAXNS itself.
+- `tests`: Matplotlib, scikit-learn, NetworkX, psutil, pytest, flake8, and
+  Ruff, matching imports and tooling used by the test and review workflows.
+
+Distributed execution is intentionally not an extra yet. Publishing an empty
+or ZMQ-only extra would imply that a distributed JAXNS entry point exists when
+it does not.
+
+## Public entry-point behavior
+
+The base environment must import `jaxns.core`, `jaxns.model`, `jaxns.state`,
+`jaxns.results`, and `jaxns.utils`, author the README-style TFP/JAXCTX model,
+and complete a small local nested-sampling run. Importing results or
+multi-ellipsoid utilities must not import Matplotlib. Plotting with the extra
+installed must continue to write files under a non-interactive backend;
+without the extra, the plotting call itself must fail with the
+`jaxns[plotting]` installation command.
+
+Wheel validation inspects `Requires-Dist` rather than only the source table,
+because the built metadata is what pip consumes. Clean-environment smokes are
+run for every supported Python version so a dependency is not classified as
+optional merely because it happens to be present transitively in the
+development environment.
+
+## Issue 256 validation record
+
+The built wheel is 113,365 bytes and declares only JAX, JAXCTX, NumPy, SciPy,
+and TFP-nightly in base metadata. Its three extras contain exactly the packages
+listed above, and it has no console-entry-point metadata for the absent fabric
+implementation.
+
+Clean base-wheel environments passed imports of `jaxns`, `core`, `model`,
+`results`, `state`, and `utils`, followed by the maintained local
+nested-sampling demo, on Python 3.10, 3.11, 3.12, 3.13, and 3.14. Matplotlib
+was absent in each base environment. Cold no-cache installs took 31--42 seconds
+on the review machine; the range is dominated by wheel download variability.
+The Python 3.12 base environment occupied 752 MiB. The parent develop wheel
+installed into an otherwise equivalent environment occupied 982 MiB and took
+42.3 seconds because it additionally downloaded and installed the Matplotlib
+stack and the `zmq` shim plus PyZMQ. The candidate wheel itself is 4,367 bytes
+larger due to the lazy-import helper and bounded-MC implementation; wheel size
+is not the install-size driver.
+
+| Python | Resolved JAX/JAXLIB | Cold install s | Environment MiB | Base import and demo |
+|---|---|---:|---:|---|
+| 3.10 | 0.6.2 | 31.00 | 797 | pass |
+| 3.11 | 0.10.2 | 31.76 | 812 | pass |
+| 3.12 | 0.11.1 | 41.81 | 752 | pass |
+| 3.13 | 0.11.1 | 32.26 | 815 | pass |
+| 3.14 | 0.11.1 | 37.47 | 848 | pass |
+
+The version differences are pip's supported-wheel resolution for each Python
+interpreter, not JAXNS pins. Removing the independent `jaxlib` declaration
+still produced the matching JAXLIB version in every row.
+
+After the base smoke, installing `jaxns[plotting]` alone supported an Agg
+backend plot and file write. Installing `jaxns[examples]` supported Matplotlib,
+Optax, and scikit-learn imports together. The missing-Matplotlib unit test
+confirms that base import remains successful and a plotting request names the
+exact `jaxns[plotting]` remedy. There is intentionally no distributed smoke:
+no distributed public operation or extra exists yet, and advertising one
+before its separately tracked design validation would be misleading.
+
+The pull-request unit-test matrix installs `jaxns[tests]`; its pip cache is
+keyed by `pyproject.toml`. The maintained demo workflow now deliberately
+installs base JAXNS because the demo is itself the clean scientific workflow.
+Read the Docs installs only its documentation tool requirements and parses the
+source tree without executing notebooks. The repository has no separate
+release-time dependency list or installer: wheel construction and publishing
+consume `pyproject.toml`, so the inspected wheel metadata is also the release
+tooling contract.

--- a/docs/design/DEPENDENCIES.md
+++ b/docs/design/DEPENDENCIES.md
@@ -25,7 +25,8 @@ operation consumes it. The source of truth for package metadata remains
   notebook and example feature set. Base modeling dependencies are inherited
   from JAXNS itself.
 - `tests`: Matplotlib, scikit-learn, NetworkX, psutil, pytest, flake8, and
-  Ruff, matching imports and tooling used by the test and review workflows.
+  Ruff, plus TOMLI on Python 3.10, matching imports and tooling used by the
+  test and review workflows.
 
 Distributed execution is intentionally not an extra yet. Publishing an empty
 or ZMQ-only extra would imply that a distributed JAXNS entry point exists when
@@ -49,7 +50,7 @@ development environment.
 
 ## Issue 256 validation record
 
-The built wheel is 113,365 bytes and declares only JAX, JAXCTX, NumPy, SciPy,
+The built wheel is 113,385 bytes and declares only JAX, JAXCTX, NumPy, SciPy,
 and TFP-nightly in base metadata. Its three extras contain exactly the packages
 listed above, and it has no console-entry-point metadata for the absent fabric
 implementation.
@@ -62,7 +63,7 @@ on the review machine; the range is dominated by wheel download variability.
 The Python 3.12 base environment occupied 752 MiB. The parent develop wheel
 installed into an otherwise equivalent environment occupied 982 MiB and took
 42.3 seconds because it additionally downloaded and installed the Matplotlib
-stack and the `zmq` shim plus PyZMQ. The candidate wheel itself is 4,367 bytes
+stack and the `zmq` shim plus PyZMQ. The candidate wheel itself is 4,387 bytes
 larger due to the lazy-import helper and bounded-MC implementation; wheel size
 is not the install-size driver.
 

--- a/docs/design/INVARIANTS.md
+++ b/docs/design/INVARIANTS.md
@@ -105,6 +105,8 @@ The exact text following each `- Invariant:` prefix is the stable key used by
 - Invariant: Dependence within a phantom cluster is preserved by sharing one random cluster
   weight across all observations and all blocks contributed by that cluster in one shrinkage
   draw.
+- Invariant: Changing how independent final Monte Carlo draws are batched does not change
+  phantom-cluster identity, the joint shrinkage law, or the evidence distribution.
 - Invariant: Phantom clusters treated as independent contributions originate from independently
   initialized stationary chains.
 - Invariant: A phantom contributes to a block only when its cluster parent contour is no
@@ -177,6 +179,9 @@ The exact text following each `- Invariant:` prefix is the stable key used by
   measure and preserves the function's pytree structure.
 - Invariant: Summary and plotting operations do not mutate the scientific result from which they
   are produced.
+- Invariant: Importing and using the non-plotting scientific API does not require plotting
+  dependencies, while requesting an unavailable optional feature fails with an actionable
+  installation remedy.
 
 ## Randomness, Numerics, And Validation
 

--- a/docs/design/REQUIREMENTS.md
+++ b/docs/design/REQUIREMENTS.md
@@ -51,6 +51,16 @@ properties that must hold independently of implementation live in
   than bespoke serialization hidden in individual algorithms.
 - Requirement: Serializing and restoring a supported state or result preserves its scientific
   arrays, model association, and posterior and evidence behavior.
+- Requirement: Runtime and optional dependencies are declared only in `pyproject.toml`, with the
+  rationale and public entry-point audit recorded in `docs/design/DEPENDENCIES.md`.
+- Requirement: The base install includes JAX, JAXCTX, NumPy, SciPy, and TFP because these support
+  the documented model-authoring, local nested-sampling, and public diagnostic workflow.
+- Requirement: JAX selects its compatible `jaxlib`; JAXNS does not independently constrain that
+  transitive runtime or interfere with accelerator-specific JAX installations.
+- Requirement: Matplotlib is supplied by the `plotting` extra and imported only when a plotting
+  operation is requested; maintained examples and tests declare plotting explicitly.
+- Requirement: Distributed dependencies and command-line entry points are not published until
+  the distributed process, serialization, and failure design is accepted and implemented.
 
 ## Core Run Architecture
 
@@ -149,6 +159,13 @@ properties that must hold independently of implementation live in
   reused for all counts and blocks from that cluster.
 - Requirement: Monte Carlo shrinkage supports bounded batching so requested draw count does not
   require materializing every draw and every block at once.
+- Requirement: Final evidence sampling defaults to an economical result without per-draw block
+  diagnostics and evaluates at most 64 independent draws per batch unless explicitly changed.
+- Requirement: Evidence batches execute sequentially at device runtime, or synchronize at a
+  host batching boundary, so asynchronous dispatch cannot make several nominally bounded
+  workspaces live concurrently.
+- Requirement: Batched per-block evidence moments are merged from first and second sufficient
+  statistics; batches are not averaged with equal weight when the final batch is partial.
 - Requirement: Phantom coordinates are not required for evidence conditioning once likelihoods,
   validity, cluster identity, and parent-contour metadata have been retained.
 

--- a/docs/user-guide/installation.rst
+++ b/docs/user-guide/installation.rst
@@ -7,6 +7,23 @@ Install the stable version with,
 
    pip install jaxns
 
+This base installation includes JAXNS model authoring and local nested
+sampling. Plotting is optional and can be installed with,
+
+.. code-block:: bash
+
+   pip install 'jaxns[plotting]'
+
+The maintained examples additionally use plotting, scikit-learn, and Optax:
+
+.. code-block:: bash
+
+   pip install 'jaxns[examples]'
+
+Distributed execution is not part of the current release API. It will receive
+an installation extra only after its process and serialization design has been
+validated.
+
 or the latest release (after appropriate dependencies) with
 
 .. code-block:: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ tests = [
     "pytest",
     "flake8",
     "ruff",
+    "tomli; python_version < '3.11'",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,21 +21,23 @@ classifiers = [
 urls = { "Homepage" = "https://github.com/joshuaalbert/jaxns" }
 dependencies = [
     "jax>=0.6.0",
-    "jaxlib",
     "jaxctx>=1.1.5",
-    "matplotlib",
     "numpy",
     "scipy",
     "tfp-nightly",
-    "zmq",
 ]
 
 [project.optional-dependencies]
+plotting = [
+    "matplotlib",
+]
 examples = [
+    "matplotlib",
     "scikit-learn",
     "optax",
 ]
 tests = [
+    "matplotlib",
     "scikit-learn",
     "networkx",
     "psutil",
@@ -43,10 +45,6 @@ tests = [
     "flake8",
     "ruff",
 ]
-
-[project.scripts]
-jaxns-fabric-scheduler = "jaxns.fabric.scheduler_launcher:main"
-jaxns-fabric-worker = "jaxns.fabric.worker_launcher:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/src/jaxns/multi_ellipsoid_utils.py
+++ b/src/jaxns/multi_ellipsoid_utils.py
@@ -1,15 +1,16 @@
-from typing import NamedTuple, Literal
+from typing import Literal, NamedTuple
 
 import jax
 import numpy as np
-import pylab as plt
-from jax import numpy as jnp, vmap, random, lax
+from jax import lax, random, vmap
+from jax import numpy as jnp
 from jax._src.scipy.special import gammaln
 
+from jaxns.em_gmm import em_gmm
 from jaxns.log_semiring import LogSpace
 from jaxns.mixed_precision import mp_policy
-from jaxns.types import PRNGKey, FloatArray, IntArray, BoolArray, UType
-from jaxns.em_gmm import em_gmm
+from jaxns.optional import import_matplotlib
+from jaxns.types import BoolArray, FloatArray, IntArray, PRNGKey, UType
 
 __all__ = [
     'ellipsoid_clustering',
@@ -625,6 +626,7 @@ def plot_ellipses(params: EllipsoidParams, show: bool = True):
         params: ellipsoid parameters to plot
         show: whether to show figure
     """
+    plt = import_matplotlib()
     theta = jnp.linspace(0., 2 * jnp.pi, 100)
     circle = jnp.stack([jnp.cos(theta), jnp.sin(theta)], axis=1)
     for mu, radii, rotation in zip(params.mu, params.radii, params.rotation):

--- a/src/jaxns/optional.py
+++ b/src/jaxns/optional.py
@@ -1,0 +1,20 @@
+"""Lazy imports for opt-in user-interface features."""
+
+
+def import_matplotlib():
+    """Import Matplotlib's pyplot module for plotting entry points.
+
+    Returns:
+        The imported ``matplotlib.pyplot`` module.
+
+    Raises:
+        ImportError: If the plotting extra is not installed correctly.
+    """
+    try:
+        from matplotlib import pyplot
+    except ImportError as error:
+        raise ImportError(
+            "JAXNS plotting requires the optional plotting dependencies. "
+            "Install them with `pip install 'jaxns[plotting]'`."
+        ) from error
+    return pyplot

--- a/src/jaxns/phantom_eval.py
+++ b/src/jaxns/phantom_eval.py
@@ -27,6 +27,12 @@ from jaxns.types import BoolArray, FloatArray, IntArray, PRNGKey
 
 @dataclasses.dataclass(slots=True, frozen=True)
 class EvidenceSamples(PureDataclassPytree):
+    """Monte Carlo evidence draws and block-aligned sufficient statistics.
+
+    The economical path retains the ``[M]`` evidence ensemble and ``[G]``
+    summaries while leaving the optional ``[M, G]`` diagnostic arrays unset.
+    """
+
     log_Z_samples: FloatArray  # [M]
     H_samples: FloatArray  # [M]
     log_dZ_mean: FloatArray  # [G]
@@ -114,6 +120,52 @@ class EvidenceSamples(PureDataclassPytree):
 
 
 EvidenceSamples.register_pytree()
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class PhantomEvents(PureDataclassPytree):
+    """Sparse interval events shared by all Monte Carlo draw batches."""
+
+    start_idx: IntArray  # [C]
+    count_A_start: FloatArray  # [C]
+    count_B_start: FloatArray  # [C]
+    event_cluster_idx: IntArray  # [E]
+    event_a_hi: IntArray  # [E]
+    event_b_hi: IntArray  # [E]
+    event_A_active: BoolArray  # [E]
+    event_B_active: BoolArray  # [E]
+    event_eq_idx: IntArray  # [E]
+    event_eq_active: BoolArray  # [E]
+    cluster_presence: FloatArray  # [C]
+    A: FloatArray  # [G]
+    B: FloatArray  # [G]
+    E: FloatArray  # [G]
+    R: FloatArray  # [G]
+    kish: FloatArray  # [G]
+    gate: BoolArray  # [G]
+
+    def aggregate(
+            self,
+            cluster_multiplicity: FloatArray,
+    ) -> tuple[FloatArray, FloatArray, FloatArray]:
+        """Aggregate weighted cluster counts over the sparse block events."""
+        return _boundary_counts_from_multiplicity(
+            cluster_multiplicity=cluster_multiplicity,
+            start_idx=self.start_idx,
+            count_A_start_per_cluster=self.count_A_start,
+            count_B_start_per_cluster=self.count_B_start,
+            event_cluster_idx=self.event_cluster_idx,
+            event_a_hi=self.event_a_hi,
+            event_b_hi=self.event_b_hi,
+            event_A_active=self.event_A_active,
+            event_B_active=self.event_B_active,
+            event_eq_idx=self.event_eq_idx,
+            event_eq_active=self.event_eq_active,
+            num_blocks=self.A.shape[0],
+        )
+
+
+PhantomEvents.register_pytree()
 
 
 def _logsumexp(x: FloatArray, axis: int | None = None) -> FloatArray:
@@ -244,6 +296,7 @@ def sample_mc_shrinkage(
         block_state: BlockState | None = None,
         batch_size: int | None = None,
         C_min: float = 20,
+        diagnostics: bool = True,
 ) -> EvidenceSamples:
     """
     Monte-Carlo evidence sampling with gamma-weighted phantom shrinkage.
@@ -265,8 +318,14 @@ def sample_mc_shrinkage(
         block_state: Optional canonical race-tree block state. When supplied, its
             block likelihoods, membership sizes, and incoming lineage counts are
             used instead of reconstructing blocks from per-sample live counts.
-        batch_size: Reserved for API compatibility; currently unused.
+        batch_size: Maximum number of independent Monte Carlo draws evaluated
+            at once. A final partial batch is supported. Batching bounds
+            working memory but full diagnostics still have an unavoidable
+            ``[num_Z_samples, num_blocks]`` output cost.
         C_min: Kish participating-cluster gate threshold. Defaults to 20.
+        diagnostics: Whether to retain per-draw, per-block probability and
+            phantom-addition arrays. Set this to false for the economical
+            evidence-summary path.
     Returns:
         EvidenceSamples with:
           - ``log_Z_samples``: evidence samples ``[num_Z_samples]``;
@@ -287,7 +346,11 @@ def sample_mc_shrinkage(
         num_samples=num_samples,
         block_state=block_state,
     )
-    return _sample_mc_shrinkage(
+    draws = _validate_mc_batching(
+        num_Z_samples=num_Z_samples,
+        batch_size=batch_size,
+    )
+    return _sample_mc_shrinkage_batches(
         key=key,
         log_L_constraints=log_L_constraints,
         log_L_classic=log_L_classic,
@@ -295,11 +358,38 @@ def sample_mc_shrinkage(
         valid_phantom=valid_phantom,
         log_L_phantom=log_L_phantom,
         num_samples=num_samples,
-        num_Z_samples=num_Z_samples,
+        num_Z_samples=draws,
         block_state=block_state,
         batch_size=batch_size,
         C_min=C_min,
+        diagnostics=diagnostics,
     )
+
+
+def _validate_mc_batching(
+        *,
+        num_Z_samples: int,
+        batch_size: int | None,
+) -> int:
+    """Validate static Monte Carlo draw counts at the Python boundary."""
+    if isinstance(num_Z_samples, bool) or not isinstance(
+            num_Z_samples,
+            (int, np.integer),
+    ):
+        raise TypeError("num_Z_samples must be a positive integer.")
+    draws = int(num_Z_samples)
+    if draws <= 0:
+        raise ValueError("num_Z_samples must be a positive integer.")
+    if batch_size is None:
+        return draws
+    if isinstance(batch_size, bool) or not isinstance(
+            batch_size,
+            (int, np.integer),
+    ):
+        raise TypeError("batch_size must be a positive integer or None.")
+    if int(batch_size) <= 0:
+        raise ValueError("batch_size must be a positive integer or None.")
+    return draws
 
 
 def validate_sample_mc_shrinkage_inputs(
@@ -1007,24 +1097,62 @@ def _summarise_gamma_log_dz_samples(
     return log_dZ_mean, log_dZ_var, weights
 
 
-def _sample_gamma_weighted_probabilities_from_events(
+def _evidence_batch_from_probabilities(
         *,
-        key: PRNGKey,
+        p_gt: FloatArray,
+        block_state: BlockState,
+) -> tuple[FloatArray, FloatArray, FloatArray]:
+    """Convert one ``[B, G]`` probability batch to evidence quantities."""
+    valid = block_state.valid
+    log_L = block_state.log_L_blocks
+    batch_size = p_gt.shape[0]
+    path_probability = jnp.where(
+        valid[None, :],
+        p_gt,
+        jnp.ones_like(p_gt),
+    )
+    path_probability = jnp.clip(path_probability, 1e-300, 1.0)
+    log_X = jnp.cumsum(jnp.log(path_probability), axis=-1)
+    log_X_prev = jnp.concatenate(
+        [
+            jnp.zeros((batch_size, 1), dtype=log_X.dtype),
+            log_X[:, :-1],
+        ],
+        axis=-1,
+    )
+    log_dX = _logdiffexp(log_X_prev, log_X)
+    log_dZ = jnp.where(
+        valid[None, :],
+        log_dX + log_L[None, :],
+        -jnp.inf,
+    )
+    log_Z = _logsumexp(log_dZ, axis=-1)
+    weights = jnp.exp(log_dZ - log_Z[:, None])
+    entropy_terms = jnp.where(
+        valid[None, :],
+        log_L[None, :] - log_Z[:, None],
+        0.0,
+    )
+    H = jnp.sum(weights * entropy_terms, axis=-1)
+    return log_Z, H, log_dZ
+
+
+def _prepare_phantom_events(
+        *,
         block_state: BlockState,
         log_L_constraints: FloatArray,
         valid_phantom: BoolArray,
         log_L_phantom: FloatArray,
         sample_mask: BoolArray,
-        num_Z_samples: int,
         C_min: float,
-):
-    """Sample phantom-conditioned races without a clusters-by-block matrix.
+) -> PhantomEvents:
+    """Build the sparse cluster events reused by every MC draw batch.
 
     Each phantom contributes interval boundaries in block index. Weighted
     cluster counts are therefore accumulated with difference arrays and
     cumulative sums. This is algebraically identical to multiplying the dense
-    A/B/E matrices by shared cluster gamma weights, but it keeps the MC path's
-    memory linear in clusters, events, blocks, and requested MC draws.
+    A/B/E matrices by shared cluster gamma weights without materialising a
+    clusters-by-block matrix.
     """
     log_L_blocks = block_state.log_L_blocks
     block_valid_mask = block_state.valid
@@ -1170,6 +1298,41 @@ def _sample_gamma_weighted_probabilities_from_events(
         & block_valid_mask
     )
 
+    return PhantomEvents(
+        start_idx=start_idx,
+        count_A_start=count_A_start,
+        count_B_start=count_B_start,
+        event_cluster_idx=event_cluster_idx,
+        event_a_hi=event_a_hi,
+        event_b_hi=event_b_hi,
+        event_A_active=event_A_active,
+        event_B_active=event_B_active,
+        event_eq_idx=event_eq_idx,
+        event_eq_active=event_eq_active,
+        cluster_presence=cluster_presence,
+        A=jnp.where(block_valid_mask, A_g, 0.0),
+        B=jnp.where(block_valid_mask, B_g, 0.0),
+        E=jnp.where(block_valid_mask, E_g, 0.0),
+        R=jnp.where(block_valid_mask, R_g, 0.0),
+        kish=jnp.where(block_valid_mask, kish, 0.0),
+        gate=gate,
+    )
+
+
+def _sample_gamma_weighted_probabilities_from_prepared_events(
+        *,
+        key: PRNGKey,
+        block_state: BlockState,
+        events: PhantomEvents,
+        num_Z_samples: int,
+) -> GammaWeightedPhantomProbabilitySamples:
+    """Draw races while reusing one deterministic sparse event plan."""
+    log_L_blocks = block_state.log_L_blocks
+    block_valid_mask = block_state.valid
+    dtype = log_L_blocks.dtype
+    num_blocks = log_L_blocks.shape[0]
+    num_clusters = events.cluster_presence.shape[0]
+
     key_gt, key_eq, key_lt, key_cluster = jax.random.split(key, 4)
     concentrations = classic_dirichlet_concentrations(block_state)
     atom_present = block_valid_mask & (concentrations.alpha_eq > 0.0)
@@ -1223,10 +1386,10 @@ def _sample_gamma_weighted_probabilities_from_events(
         shape=(num_Z_samples, num_clusters),
         dtype=dtype,
     )
-    weighted_A, weighted_B, weighted_E = jax.vmap(aggregate)(
-        cluster_weights * cluster_presence[None, :]
+    weighted_A, weighted_B, weighted_E = jax.vmap(events.aggregate)(
+        cluster_weights * events.cluster_presence[None, :]
     )
-    gate_value = gate.astype(dtype)[None, :]
+    gate_value = events.gate.astype(dtype)[None, :]
     # A singleton block is structurally two-class. Exact equality
     # observations therefore belong to the A-B complement; only a plateau
     # block may allocate them to a separate equality mass.
@@ -1252,16 +1415,53 @@ def _sample_gamma_weighted_probabilities_from_events(
         phantom_add_lt_samples=phantom_add_lt,
         kish_participating_cluster_counts=jnp.where(
             block_valid_mask,
-            kish,
+            events.kish,
             0.0,
         ),
-        phantom_gate_active=gate,
+        phantom_gate_active=events.gate,
         race_gamma_gt=race_gt,
         race_gamma_eq=race_eq,
         race_gamma_lt=race_lt,
         cluster_weights=cluster_weights,
     )
-    return probabilities, A_g, B_g, E_g, R_g, kish, gate
+    return probabilities
+
+
+def _sample_gamma_weighted_probabilities_from_events(
+        *,
+        key: PRNGKey,
+        block_state: BlockState,
+        log_L_constraints: FloatArray,
+        valid_phantom: BoolArray,
+        log_L_phantom: FloatArray,
+        sample_mask: BoolArray,
+        num_Z_samples: int,
+        C_min: float,
+):
+    """Sample phantom-conditioned races without dense count matrices."""
+    events = _prepare_phantom_events(
+        block_state=block_state,
+        log_L_constraints=log_L_constraints,
+        valid_phantom=valid_phantom,
+        log_L_phantom=log_L_phantom,
+        sample_mask=sample_mask,
+        C_min=C_min,
+    )
+    probabilities = _sample_gamma_weighted_probabilities_from_prepared_events(
+        key=key,
+        block_state=block_state,
+        events=events,
+        num_Z_samples=num_Z_samples,
+    )
+    return (
+        probabilities,
+        events.A,
+        events.B,
+        events.E,
+        events.R,
+        events.kish,
+        events.gate,
+    )
 
 
 def _sample_mc_shrinkage(
@@ -1275,10 +1475,9 @@ def _sample_mc_shrinkage(
         num_Z_samples: int,
         *,
         block_state: BlockState | None = None,
-        batch_size: int | None = None,
         C_min: float = 20,
+        diagnostics: bool = True,
 ) -> EvidenceSamples:
-    del batch_size
     N = log_L_classic.shape[0]
     sample_valid_mask = jnp.arange(N, dtype=jnp.int32) < num_samples
     positive_live_mask = K_classic > 0
@@ -1381,9 +1580,13 @@ def _sample_mc_shrinkage(
         )
         H_samples = jnp.sum(weights * entropy_terms, axis=-1)
         zeros = jnp.zeros((num_blocks,), dtype=log_L_blocks.dtype)
-        zero_additions = jnp.zeros(
-            (num_Z_samples, num_blocks),
-            dtype=log_L_blocks.dtype,
+        zero_additions = (
+            jnp.zeros(
+                (num_Z_samples, num_blocks),
+                dtype=log_L_blocks.dtype,
+            )
+            if diagnostics
+            else None
         )
         return EvidenceSamples(
             log_Z_samples=log_Z_samples,
@@ -1407,9 +1610,9 @@ def _sample_mc_shrinkage(
             classic_alpha_eq=classic_concentrations.alpha_eq,
             classic_alpha_lt=classic_concentrations.alpha_lt,
             epsilon=classic_concentrations.epsilon,
-            p_gt_samples=p_gt_samples,
-            p_eq_samples=p_eq_samples,
-            p_lt_samples=p_lt_samples,
+            p_gt_samples=p_gt_samples if diagnostics else None,
+            p_eq_samples=p_eq_samples if diagnostics else None,
+            p_lt_samples=p_lt_samples if diagnostics else None,
             p_gt_mean=jnp.mean(p_gt_samples, axis=0),
             p_eq_mean=jnp.mean(p_eq_samples, axis=0),
             p_lt_mean=jnp.mean(p_lt_samples, axis=0),
@@ -1494,13 +1697,403 @@ def _sample_mc_shrinkage(
         classic_alpha_eq=classic_concentrations.alpha_eq,
         classic_alpha_lt=classic_concentrations.alpha_lt,
         epsilon=classic_concentrations.epsilon,
-        p_gt_samples=probability_samples.p_gt_samples,
-        p_eq_samples=probability_samples.p_eq_samples,
-        p_lt_samples=probability_samples.p_lt_samples,
+        p_gt_samples=(
+            probability_samples.p_gt_samples if diagnostics else None
+        ),
+        p_eq_samples=(
+            probability_samples.p_eq_samples if diagnostics else None
+        ),
+        p_lt_samples=(
+            probability_samples.p_lt_samples if diagnostics else None
+        ),
         p_gt_mean=jnp.where(block_valid_mask, p_gt_mean, jnp.nan),
         p_eq_mean=jnp.where(block_valid_mask, p_eq_mean, jnp.nan),
         p_lt_mean=jnp.where(block_valid_mask, p_lt_mean, jnp.nan),
-        phantom_add_gt_samples=probability_samples.phantom_add_gt_samples,
-        phantom_add_eq_samples=probability_samples.phantom_add_eq_samples,
-        phantom_add_lt_samples=probability_samples.phantom_add_lt_samples,
+        phantom_add_gt_samples=(
+            probability_samples.phantom_add_gt_samples
+            if diagnostics
+            else None
+        ),
+        phantom_add_eq_samples=(
+            probability_samples.phantom_add_eq_samples
+            if diagnostics
+            else None
+        ),
+        phantom_add_lt_samples=(
+            probability_samples.phantom_add_lt_samples
+            if diagnostics
+            else None
+        ),
+    )
+
+
+def _sample_mc_shrinkage_summary(
+        key: PRNGKey,
+        log_L_constraints: FloatArray,
+        log_L_classic: FloatArray,
+        K_classic: IntArray,
+        valid_phantom: BoolArray,
+        log_L_phantom: FloatArray,
+        num_samples: IntArray,
+        num_Z_samples: int,
+        *,
+        block_state: BlockState,
+        batch_size: int,
+        C_min: float,
+) -> EvidenceSamples:
+    """Stream bounded batches inside one compiled evidence program."""
+    sample_mask = (
+        jnp.arange(log_L_classic.shape[0], dtype=jnp.int32) < num_samples
+    ) & (K_classic > 0)
+    concentrations = classic_dirichlet_concentrations(block_state)
+    valid = block_state.valid
+    dtype = block_state.log_L_blocks.dtype
+    num_blocks = block_state.log_L_blocks.shape[0]
+    num_batches = (num_Z_samples + batch_size - 1) // batch_size
+    draw_indices = jnp.arange(batch_size, dtype=jnp.int32)
+
+    if log_L_phantom.shape[1] == 0:
+        events = None
+        zeros = jnp.zeros((num_blocks,), dtype=dtype)
+        kish = zeros
+        gate = jnp.zeros((num_blocks,), dtype=mp_policy.bool_dtype)
+        phantom_A = zeros
+        phantom_B = zeros
+        phantom_E = zeros
+        phantom_R = zeros
+    else:
+        # Sorting and Kish-count preparation depend only on the completed
+        # race tree. Keep them outside the scan so increasing the number of
+        # MC batches does not repeat deterministic work.
+        events = _prepare_phantom_events(
+            block_state=block_state,
+            log_L_constraints=log_L_constraints,
+            valid_phantom=valid_phantom,
+            log_L_phantom=log_L_phantom,
+            sample_mask=sample_mask,
+            C_min=C_min,
+        )
+        kish = events.kish
+        gate = events.gate
+        phantom_A = events.A
+        phantom_B = events.B
+        phantom_E = events.E
+        phantom_R = events.R
+
+    def sample_batch(carry, batch_index):
+        # A scan makes batches sequential at device runtime, bounding the
+        # workspace while retaining vmap within each independent draw batch.
+        # This is separate from replacement sampling, whose width remains one
+        # parallel vmap in the nested-sampling depth loop.
+        batch_key = (
+            key
+            if num_batches == 1
+            else jax.random.fold_in(key, batch_index)
+        )
+        if events is None:
+            p_gt, p_eq, p_lt = sample_dirichlet_probabilities(
+                batch_key,
+                concentrations,
+                num_samples=batch_size,
+            )
+        else:
+            probability_samples = (
+                _sample_gamma_weighted_probabilities_from_prepared_events(
+                    key=batch_key,
+                    block_state=block_state,
+                    events=events,
+                    num_Z_samples=batch_size,
+                )
+            )
+            p_gt = probability_samples.p_gt_samples
+            p_eq = probability_samples.p_eq_samples
+            p_lt = probability_samples.p_lt_samples
+        log_Z, H, log_dZ = _evidence_batch_from_probabilities(
+            p_gt=p_gt,
+            block_state=block_state,
+        )
+        draw_mask = (
+            batch_index * batch_size + draw_indices < num_Z_samples
+        )
+        masked_log_dZ = jnp.where(draw_mask[:, None], log_dZ, -jnp.inf)
+        (
+            log_dZ_sum,
+            log_dZ_second_sum,
+            p_gt_sum,
+            p_eq_sum,
+            p_lt_sum,
+        ) = carry
+        # Only the required [M] evidence ensemble is emitted by the scan.
+        # Block summaries stay in the [G] carry, so even batch_size=1 cannot
+        # recreate a hidden [num_batches, G] memory cost.
+        updated = (
+            jnp.logaddexp(
+                log_dZ_sum,
+                _logsumexp(masked_log_dZ, axis=0),
+            ),
+            jnp.logaddexp(
+                log_dZ_second_sum,
+                _logsumexp(2.0 * masked_log_dZ, axis=0),
+            ),
+            p_gt_sum + jnp.sum(
+                jnp.where(draw_mask[:, None], p_gt, 0.0),
+                axis=0,
+            ),
+            p_eq_sum + jnp.sum(
+                jnp.where(draw_mask[:, None], p_eq, 0.0),
+                axis=0,
+            ),
+            p_lt_sum + jnp.sum(
+                jnp.where(draw_mask[:, None], p_lt, 0.0),
+                axis=0,
+            ),
+        )
+        emitted = (
+            jnp.where(draw_mask, log_Z, 0.0),
+            jnp.where(draw_mask, H, 0.0),
+        )
+        return updated, emitted
+
+    initial = (
+        jnp.full((num_blocks,), -jnp.inf, dtype=dtype),
+        jnp.full((num_blocks,), -jnp.inf, dtype=dtype),
+        jnp.zeros((num_blocks,), dtype=dtype),
+        jnp.zeros((num_blocks,), dtype=dtype),
+        jnp.zeros((num_blocks,), dtype=dtype),
+    )
+    summaries, batches = jax.lax.scan(
+        sample_batch,
+        initial,
+        jnp.arange(num_batches, dtype=jnp.int32),
+    )
+    (
+        log_dZ_sums,
+        log_dZ_second_sums,
+        p_gt_sums,
+        p_eq_sums,
+        p_lt_sums,
+    ) = summaries
+    log_Z_batches, H_batches = batches
+    log_draws = jnp.log(jnp.asarray(num_Z_samples, dtype=dtype))
+    log_dZ_mean = log_dZ_sums - log_draws
+    log_dZ_second = log_dZ_second_sums - log_draws
+    log_dZ_mean_sq = 2.0 * log_dZ_mean
+    log_dZ_var = jnp.where(
+        log_dZ_second > log_dZ_mean_sq,
+        _logdiffexp(log_dZ_second, log_dZ_mean_sq),
+        jnp.full_like(log_dZ_mean, -jnp.inf),
+    )
+    p_gt_mean = p_gt_sums / num_Z_samples
+    p_eq_mean = p_eq_sums / num_Z_samples
+    p_lt_mean = p_lt_sums / num_Z_samples
+    return EvidenceSamples(
+        log_Z_samples=log_Z_batches.reshape((-1,))[:num_Z_samples],
+        H_samples=H_batches.reshape((-1,))[:num_Z_samples],
+        log_dZ_mean=jnp.where(valid, log_dZ_mean, -jnp.inf),
+        log_dZ_var=jnp.where(valid, log_dZ_var, -jnp.inf),
+        log_L_blocks=block_state.log_L_blocks,
+        block_first_idx=block_state.block_first_idx.astype(jnp.int32),
+        block_size=block_state.block_size.astype(jnp.int32),
+        incoming_K=block_state.incoming_K.astype(jnp.int32),
+        kish_participating_cluster_counts=kish,
+        phantom_gate_active=gate,
+        phantom_A=phantom_A,
+        phantom_B=phantom_B,
+        phantom_E=phantom_E,
+        phantom_R=phantom_R,
+        classic_alpha_gt=concentrations.alpha_gt,
+        classic_alpha_eq=concentrations.alpha_eq,
+        classic_alpha_lt=concentrations.alpha_lt,
+        epsilon=concentrations.epsilon,
+        p_gt_samples=None,
+        p_eq_samples=None,
+        p_lt_samples=None,
+        p_gt_mean=jnp.where(valid, p_gt_mean, jnp.nan),
+        p_eq_mean=jnp.where(valid, p_eq_mean, jnp.nan),
+        p_lt_mean=jnp.where(valid, p_lt_mean, jnp.nan),
+        phantom_add_gt_samples=None,
+        phantom_add_eq_samples=None,
+        phantom_add_lt_samples=None,
+    )
+
+
+_sample_mc_shrinkage_jit = jax.jit(
+    _sample_mc_shrinkage,
+    static_argnames=("num_Z_samples", "diagnostics"),
+)
+
+_sample_mc_shrinkage_summary_jit = jax.jit(
+    _sample_mc_shrinkage_summary,
+    static_argnames=("num_Z_samples", "batch_size"),
+)
+
+
+def _sample_mc_shrinkage_batches(
+        key: PRNGKey,
+        log_L_constraints: FloatArray,
+        log_L_classic: FloatArray,
+        K_classic: IntArray,
+        valid_phantom: BoolArray,
+        log_L_phantom: FloatArray,
+        num_samples: IntArray,
+        num_Z_samples: int,
+        *,
+        block_state: BlockState | None,
+        batch_size: int | None,
+        C_min: float,
+        diagnostics: bool,
+) -> EvidenceSamples:
+    """Run independent draw batches and merge their sufficient statistics."""
+    size = num_Z_samples if batch_size is None else min(
+        int(batch_size),
+        num_Z_samples,
+    )
+    if not diagnostics and block_state is not None:
+        return _sample_mc_shrinkage_summary_jit(
+            key=key,
+            log_L_constraints=log_L_constraints,
+            log_L_classic=log_L_classic,
+            K_classic=K_classic,
+            valid_phantom=valid_phantom,
+            log_L_phantom=log_L_phantom,
+            num_samples=num_samples,
+            num_Z_samples=num_Z_samples,
+            block_state=block_state,
+            batch_size=size,
+            C_min=C_min,
+        )
+    batch_draws = [
+        min(size, num_Z_samples - start)
+        for start in range(0, num_Z_samples, size)
+    ]
+    # Preserve the original fixed-key result when no batching is necessary.
+    # Multiple batches receive independent streams, but a boundary never
+    # changes the definition or weight of a phantom cluster within a draw.
+    keys = (
+        [key]
+        if len(batch_draws) == 1
+        else list(jax.random.split(key, len(batch_draws)))
+    )
+    kernel = (
+        _sample_mc_shrinkage
+        if block_state is None
+        else _sample_mc_shrinkage_jit
+    )
+    log_Z_batches = []
+    H_batches = []
+    log_dZ_sums = []
+    log_dZ_second_sums = []
+    p_gt_sums = []
+    p_eq_sums = []
+    p_lt_sums = []
+    p_gt_batches = [] if diagnostics else None
+    p_eq_batches = [] if diagnostics else None
+    p_lt_batches = [] if diagnostics else None
+    add_gt_batches = [] if diagnostics else None
+    add_eq_batches = [] if diagnostics else None
+    add_lt_batches = [] if diagnostics else None
+    first = None
+
+    for batch_key, draws in zip(keys, batch_draws):
+        samples = kernel(
+            key=batch_key,
+            log_L_constraints=log_L_constraints,
+            log_L_classic=log_L_classic,
+            K_classic=K_classic,
+            valid_phantom=valid_phantom,
+            log_L_phantom=log_L_phantom,
+            num_samples=num_samples,
+            num_Z_samples=draws,
+            block_state=block_state,
+            C_min=C_min,
+            diagnostics=diagnostics,
+        )
+        # JAX dispatch is asynchronous. Waiting here prevents several batch
+        # workspaces from being live concurrently and makes `batch_size` a
+        # real peak-memory bound rather than only a nominal array shape.
+        jax.block_until_ready(samples)
+        if first is None:
+            first = samples
+        log_Z_batches.append(samples.log_Z_samples)
+        H_batches.append(samples.H_samples)
+        dtype = samples.log_dZ_mean.dtype
+        log_count = jnp.log(jnp.asarray(draws, dtype=dtype))
+        log_dZ_sums.append(samples.log_dZ_mean + log_count)
+        log_dZ_second_sums.append(
+            jnp.logaddexp(
+                samples.log_dZ_var,
+                2.0 * samples.log_dZ_mean,
+            ) + log_count
+        )
+        p_gt_sums.append(samples.p_gt_mean * draws)
+        p_eq_sums.append(samples.p_eq_mean * draws)
+        p_lt_sums.append(samples.p_lt_mean * draws)
+        if diagnostics:
+            p_gt_batches.append(samples.p_gt_samples)
+            p_eq_batches.append(samples.p_eq_samples)
+            p_lt_batches.append(samples.p_lt_samples)
+            add_gt_batches.append(samples.phantom_add_gt_samples)
+            add_eq_batches.append(samples.phantom_add_eq_samples)
+            add_lt_batches.append(samples.phantom_add_lt_samples)
+
+    dtype = first.log_dZ_mean.dtype
+    log_draws = jnp.log(jnp.asarray(num_Z_samples, dtype=dtype))
+    log_dZ_mean = _logsumexp(jnp.stack(log_dZ_sums), axis=0) - log_draws
+    log_dZ_second = (
+        _logsumexp(jnp.stack(log_dZ_second_sums), axis=0) - log_draws
+    )
+    log_dZ_mean_sq = 2.0 * log_dZ_mean
+    log_dZ_var = jnp.where(
+        log_dZ_second > log_dZ_mean_sq,
+        _logdiffexp(log_dZ_second, log_dZ_mean_sq),
+        jnp.full_like(log_dZ_mean, -jnp.inf),
+    )
+    p_gt_mean = jnp.sum(jnp.stack(p_gt_sums), axis=0) / num_Z_samples
+    p_eq_mean = jnp.sum(jnp.stack(p_eq_sums), axis=0) / num_Z_samples
+    p_lt_mean = jnp.sum(jnp.stack(p_lt_sums), axis=0) / num_Z_samples
+    # Block membership is the canonical validity marker. A finite-likelihood
+    # test would incorrectly reject a legitimate positive-infinite contour.
+    valid = first.block_size > 0
+    return EvidenceSamples(
+        log_Z_samples=jnp.concatenate(log_Z_batches),
+        H_samples=jnp.concatenate(H_batches),
+        log_dZ_mean=jnp.where(valid, log_dZ_mean, -jnp.inf),
+        log_dZ_var=jnp.where(valid, log_dZ_var, -jnp.inf),
+        log_L_blocks=first.log_L_blocks,
+        block_first_idx=first.block_first_idx,
+        block_size=first.block_size,
+        incoming_K=first.incoming_K,
+        kish_participating_cluster_counts=(
+            first.kish_participating_cluster_counts
+        ),
+        phantom_gate_active=first.phantom_gate_active,
+        phantom_A=first.phantom_A,
+        phantom_B=first.phantom_B,
+        phantom_E=first.phantom_E,
+        phantom_R=first.phantom_R,
+        classic_alpha_gt=first.classic_alpha_gt,
+        classic_alpha_eq=first.classic_alpha_eq,
+        classic_alpha_lt=first.classic_alpha_lt,
+        epsilon=first.epsilon,
+        p_gt_samples=(
+            jnp.concatenate(p_gt_batches) if diagnostics else None
+        ),
+        p_eq_samples=(
+            jnp.concatenate(p_eq_batches) if diagnostics else None
+        ),
+        p_lt_samples=(
+            jnp.concatenate(p_lt_batches) if diagnostics else None
+        ),
+        p_gt_mean=jnp.where(valid, p_gt_mean, jnp.nan),
+        p_eq_mean=jnp.where(valid, p_eq_mean, jnp.nan),
+        p_lt_mean=jnp.where(valid, p_lt_mean, jnp.nan),
+        phantom_add_gt_samples=(
+            jnp.concatenate(add_gt_batches) if diagnostics else None
+        ),
+        phantom_add_eq_samples=(
+            jnp.concatenate(add_eq_batches) if diagnostics else None
+        ),
+        phantom_add_lt_samples=(
+            jnp.concatenate(add_lt_batches) if diagnostics else None
+        ),
     )

--- a/src/jaxns/results.py
+++ b/src/jaxns/results.py
@@ -8,7 +8,6 @@ from typing import Literal, TextIO, TypeVar
 
 import jax
 import numpy as np
-import pylab as plt
 from jax import numpy as jnp
 from jaxctx.context import CtxParams
 from scipy.stats import gaussian_kde
@@ -16,14 +15,12 @@ from scipy.stats import gaussian_kde
 from jaxns.cumulative_ops import batch_reduce
 from jaxns.log_semiring import LogSpace, cumulative_logsumexp, normalise_log_space
 from jaxns.mixed_precision import mp_policy
+from jaxns.optional import import_matplotlib
 from jaxns.phantom_eval import (
     EvidenceSamples,
     compute_phantom_count_matrices,
     sample_mc_shrinkage,
     validate_sample_mc_shrinkage_inputs,
-)
-from jaxns.phantom_eval import (
-    _sample_mc_shrinkage as _phantom_eval_sample_mc_shrinkage,
 )
 from jaxns.pytree import PureDataclassPytree
 from jaxns.race_tree import BlockState
@@ -33,6 +30,7 @@ from jaxns.types import BoolArray, FloatArray, IntArray, PRNGKey, UType, XType
 
 MF = TypeVar('MF')
 EvidenceConditioning = Literal["classic", "phantom"]
+DEFAULT_MC_BATCH_SIZE = 64
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
@@ -271,7 +269,8 @@ class NestedSamplerResults(PureDataclassPytree):
 
         Args:
             num_samples: number of evidence samples to draw
-            batch_size: optional, how many samples to process in a batch when applying the function.
+            batch_size: Maximum simultaneous evidence draws. ``None`` uses
+                the same bounded 64-draw default as ``sample_evidence_mc``.
             key: optional, PRNGKey for resampling
 
         Returns:
@@ -288,6 +287,7 @@ class NestedSamplerResults(PureDataclassPytree):
             key: PRNGKey | None = None,
             C_min: float = 20,
             conditioning: Literal["auto", "classic", "phantom"] = "auto",
+            diagnostics: bool = True,
     ) -> EvidenceSamples:
         """
         Sample the evidence using the MC shrinkage method.
@@ -296,6 +296,10 @@ class NestedSamplerResults(PureDataclassPytree):
             num_samples: number of evidence samples to draw
             batch_size: optional, how many samples to process in a batch when applying the function.
             key: optional, PRNGKey for resampling
+            C_min: Minimum participating-cluster Kish count.
+            conditioning: Whether to use retained phantom clusters.
+            diagnostics: Whether to retain full per-draw, per-block arrays.
+                These arrays have shape ``[num_samples, num_blocks]``.
 
         Returns:
             EvidenceSamples object containing samples of the evidence and related statistics.
@@ -332,6 +336,7 @@ class NestedSamplerResults(PureDataclassPytree):
                 batch_size=batch_size,
                 key=key,
                 C_min=C_min,
+                diagnostics=diagnostics,
             )
         return _sample_mc_shrinkage(
             results,
@@ -339,6 +344,7 @@ class NestedSamplerResults(PureDataclassPytree):
             batch_size=batch_size,
             key=key,
             C_min=C_min,
+            diagnostics=diagnostics,
         )
 
     def sample_evidence_mc(
@@ -349,6 +355,7 @@ class NestedSamplerResults(PureDataclassPytree):
             key: PRNGKey,
             batch_size: int | None = None,
             C_min: float = 20,
+            diagnostics: bool = False,
     ) -> EvidenceSamples:
         """Draw the authoritative final evidence ensemble.
 
@@ -357,8 +364,12 @@ class NestedSamplerResults(PureDataclassPytree):
             conditioning: ``"classic"`` ignores retained phantoms;
                 ``"phantom"`` uses retained clusters subject to the Kish gate.
             key: Explicit JAX PRNG key.
-            batch_size: Optional compatibility batching parameter.
+            batch_size: Maximum number of draws evaluated at once. ``None``
+                uses an automatically bounded batch of at most 64 draws.
             C_min: Minimum participating-cluster Kish count for conditioning.
+            diagnostics: Whether to retain full ``[num_samples, num_blocks]``
+                probability and phantom-addition arrays. Defaults to the
+                economical evidence-summary path.
 
         Returns:
             Evidence draws whose ``log_Z_mean`` and ``log_Z_uncert``
@@ -373,12 +384,15 @@ class NestedSamplerResults(PureDataclassPytree):
                 "Phantom conditioning was requested, but no phantom slots "
                 "were collected."
             )
+        if batch_size is None:
+            batch_size = min(num_samples, DEFAULT_MC_BATCH_SIZE)
         return self.sample_mc_shrinkage(
             num_samples=num_samples,
             batch_size=batch_size,
             key=key,
             C_min=C_min,
             conditioning=conditioning,
+            diagnostics=diagnostics,
         )
 
     def phantom_conditioning_diagnostics(
@@ -676,6 +690,9 @@ def plot_diagnostics(results: NestedSamplerResults, save_file=None):
         save_file: file to save figure to.
     """
 
+    # Plotting is optional so importing the scientific result type does not
+    # force non-plotting users to install a GUI-oriented dependency stack.
+    plt = import_matplotlib()
     num_samples = int(results.total_num_samples)
     fig, axs = plt.subplots(6, 1, sharex=True, figsize=(8, 15))
     log_X = np.asarray(results.log_X_mean[:num_samples])
@@ -743,6 +760,8 @@ def plot_diagnostics(results: NestedSamplerResults, save_file=None):
 
 def _sample_evidence(self: NestedSamplerResults,
                      num_samples: int = 100, batch_size: int | None = None, key: PRNGKey | None = None) -> FloatArray:
+    if batch_size is None:
+        batch_size = min(num_samples, DEFAULT_MC_BATCH_SIZE)
     evidence_samples = sample_mc_shrinkage(
         key=key,
         log_L_constraints=self.log_L_constraints,
@@ -754,6 +773,7 @@ def _sample_evidence(self: NestedSamplerResults,
         num_Z_samples=num_samples,
         block_state=_block_state_from_results(self),
         batch_size=batch_size,
+        diagnostics=False,
     )
     return evidence_samples.log_Z_samples
 
@@ -761,7 +781,8 @@ def _sample_evidence(self: NestedSamplerResults,
 def _sample_mc_shrinkage(self: NestedSamplerResults,
                          num_samples: int = 100, batch_size: int | None = None,
                          key: PRNGKey | None = None,
-                         C_min: float = 20) -> EvidenceSamples:
+                         C_min: float = 20,
+                         diagnostics: bool = True) -> EvidenceSamples:
     evidence_samples = sample_mc_shrinkage(
         key=key,
         log_L_constraints=self.log_L_constraints,
@@ -774,6 +795,7 @@ def _sample_mc_shrinkage(self: NestedSamplerResults,
         block_state=_block_state_from_results(self),
         batch_size=batch_size,
         C_min=C_min,
+        diagnostics=diagnostics,
     )
     return evidence_samples
 
@@ -786,49 +808,21 @@ def _sample_mc_shrinkage_with_block_state(
         batch_size: int | None = None,
         key: PRNGKey,
         C_min: float = 20,
+        diagnostics: bool = True,
 ) -> EvidenceSamples:
-    return _sample_mc_shrinkage_with_block_state_jit(
+    return sample_mc_shrinkage(
         key=key,
         log_L_constraints=results.log_L_constraints,
         log_L_classic=results.log_L,
         K_classic=results.num_live_points_per_sample,
         valid_phantom=results.valid_phantom,
         log_L_phantom=results.log_L_phantom,
-        total_num_samples=results.total_num_samples,
+        num_samples=results.total_num_samples,
         num_Z_samples=num_samples,
         block_state=block_state,
         batch_size=batch_size,
         C_min=C_min,
-    )
-
-
-@partial(jax.jit, inline=True, static_argnames=["num_Z_samples", "batch_size"])
-def _sample_mc_shrinkage_with_block_state_jit(
-        *,
-        key: PRNGKey,
-        log_L_constraints: FloatArray,
-        log_L_classic: FloatArray,
-        K_classic: IntArray,
-        valid_phantom: BoolArray,
-        log_L_phantom: FloatArray,
-        total_num_samples: IntArray,
-        num_Z_samples: int,
-        block_state: BlockState,
-        batch_size: int | None = None,
-        C_min: float = 20,
-) -> EvidenceSamples:
-    return _phantom_eval_sample_mc_shrinkage(
-        key=key,
-        log_L_constraints=log_L_constraints,
-        log_L_classic=log_L_classic,
-        K_classic=K_classic,
-        valid_phantom=valid_phantom,
-        log_L_phantom=log_L_phantom,
-        num_samples=total_num_samples,
-        num_Z_samples=num_Z_samples,
-        block_state=block_state,
-        batch_size=batch_size,
-        C_min=C_min,
+        diagnostics=diagnostics,
     )
 
 
@@ -860,6 +854,9 @@ def plot_cornerplot(results: NestedSamplerResults, variables: list[str] | None =
         save_name: file to save result to.
         kde_overlay: whether to overlay a KDE on the histograms.
     """
+    # Keep the optional dependency behind the operation that needs it and
+    # provide one consistent installation remedy when it is unavailable.
+    plt = import_matplotlib()
     num_samples = int(results.total_num_samples)
     sample_items = list(results.X_samples.iter_items())
     sample_map = dict(sample_items)

--- a/src/jaxns/state.py
+++ b/src/jaxns/state.py
@@ -129,12 +129,26 @@ class State(PureDataclassPytree):
             key: jax.Array,
             batch_size: int | None = None,
             C_min: float = 20,
+            diagnostics: bool = False,
     ) -> EvidenceSamples:
         """Draw final evidence samples from this immutable state.
 
         This is a thin state-level forwarder to the same result implementation
         used after a run. ``conditioning`` must explicitly be ``"classic"``
         or ``"phantom"``; the depth-loop expectation register is not used.
+
+        Args:
+            num_samples: Number of evidence draws.
+            conditioning: Whether to use only the classic race or condition
+                on retained phantom clusters.
+            key: Explicit JAX random key.
+            batch_size: Maximum simultaneous evidence draws. ``None`` uses
+                the bounded result-level default.
+            C_min: Minimum participating-cluster Kish count.
+            diagnostics: Whether to retain full per-draw, per-block arrays.
+
+        Returns:
+            The evidence ensemble and its block-aligned summaries.
         """
         return self.to_result().trim().sample_evidence_mc(
             num_samples=num_samples,
@@ -142,6 +156,7 @@ class State(PureDataclassPytree):
             key=key,
             batch_size=batch_size,
             C_min=C_min,
+            diagnostics=diagnostics,
         )
 
     def compute_termination_register(

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,42 @@
+import builtins
+from pathlib import Path
+
+import pytest
+import tomllib
+
+from jaxns.optional import import_matplotlib
+
+
+def test_missing_plotting_dependency_has_actionable_error(monkeypatch):
+    real_import = builtins.__import__
+
+    def block_matplotlib(name, *args, **kwargs):
+        if name == "matplotlib" or name.startswith("matplotlib."):
+            raise ModuleNotFoundError("No module named 'matplotlib'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", block_matplotlib)
+
+    with pytest.raises(ImportError, match=r"jaxns\[plotting\]"):
+        import_matplotlib()
+
+
+def test_dependency_metadata_matches_feature_boundaries():
+    root = Path(__file__).resolve().parents[1]
+    with (root / "pyproject.toml").open("rb") as file:
+        project = tomllib.load(file)["project"]
+
+    base = set(project["dependencies"])
+    extras = project["optional-dependencies"]
+    assert "jax>=0.6.0" in base
+    assert "jaxctx>=1.1.5" in base
+    assert "numpy" in base
+    assert "scipy" in base
+    assert "tfp-nightly" in base
+    assert "jaxlib" not in base
+    assert "matplotlib" not in base
+    assert "zmq" not in base
+    assert extras["plotting"] == ["matplotlib"]
+    assert "matplotlib" in extras["examples"]
+    assert "matplotlib" in extras["tests"]
+    assert "scripts" not in project

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -2,7 +2,11 @@ import builtins
 from pathlib import Path
 
 import pytest
-import tomllib
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 test environment.
+    import tomli as tomllib
 
 from jaxns.optional import import_matplotlib
 
@@ -39,4 +43,5 @@ def test_dependency_metadata_matches_feature_boundaries():
     assert extras["plotting"] == ["matplotlib"]
     assert "matplotlib" in extras["examples"]
     assert "matplotlib" in extras["tests"]
+    assert "tomli; python_version < '3.11'" in extras["tests"]
     assert "scripts" not in project

--- a/tests/test_phantom_results.py
+++ b/tests/test_phantom_results.py
@@ -467,6 +467,196 @@ def test_results_sample_mc_shrinkage_uses_gamma_conditioning_when_gate_active():
     )
 
 
+@pytest.mark.parametrize("batch_size", [1, 4, 10, 64])
+def test_sample_evidence_mc_batches_have_exact_requested_shape(batch_size):
+    """Cover single, partial-final, exact, and larger-than-request batches."""
+    results = _make_single_block_gamma_public_result()
+
+    samples = results.sample_evidence_mc(
+        num_samples=10,
+        conditioning="phantom",
+        key=jax.random.PRNGKey(211),
+        batch_size=batch_size,
+    )
+
+    assert samples.log_Z_samples.shape == (10,)
+    assert samples.H_samples.shape == (10,)
+    assert samples.p_gt_samples is None
+    assert samples.p_eq_samples is None
+    assert samples.p_lt_samples is None
+    assert samples.phantom_add_gt_samples is None
+    assert np.all(np.isfinite(np.asarray(samples.log_Z_samples)))
+
+
+def test_sample_evidence_mc_batching_is_reproducible_and_matches_moments():
+    """A fixed key is repeatable and batching preserves the sampled law."""
+    results = _make_single_block_gamma_public_result()
+    key = jax.random.PRNGKey(223)
+    num_draws = 4096
+
+    batched = results.sample_evidence_mc(
+        num_samples=num_draws,
+        conditioning="phantom",
+        key=key,
+        batch_size=257,
+    )
+    repeated = results.sample_evidence_mc(
+        num_samples=num_draws,
+        conditioning="phantom",
+        key=key,
+        batch_size=257,
+    )
+    unbatched = results.sample_mc_shrinkage(
+        num_samples=num_draws,
+        conditioning="phantom",
+        key=key,
+        diagnostics=False,
+    )
+
+    np.testing.assert_array_equal(
+        np.asarray(batched.log_Z_samples),
+        np.asarray(repeated.log_Z_samples),
+    )
+    np.testing.assert_allclose(
+        float(batched.log_Z_mean),
+        float(unbatched.log_Z_mean),
+        atol=0.03,
+        rtol=0.0,
+    )
+    np.testing.assert_allclose(
+        float(batched.log_Z_uncert),
+        float(unbatched.log_Z_uncert),
+        atol=0.03,
+        rtol=0.0,
+    )
+    np.testing.assert_allclose(
+        np.asarray(batched.p_gt_mean),
+        np.asarray(unbatched.p_gt_mean),
+        atol=0.02,
+        rtol=0.0,
+    )
+    np.testing.assert_allclose(
+        np.exp(np.asarray(batched.log_dZ_mean)),
+        np.exp(np.asarray(unbatched.log_dZ_mean)),
+        atol=0.02,
+        rtol=0.0,
+    )
+
+
+def test_sample_evidence_mc_one_batch_preserves_fixed_key_draws():
+    results = _make_single_block_gamma_public_result()
+    key = jax.random.PRNGKey(227)
+
+    unbatched = results.sample_mc_shrinkage(
+        num_samples=10,
+        conditioning="phantom",
+        key=key,
+        diagnostics=False,
+    )
+    larger_batch = results.sample_evidence_mc(
+        num_samples=10,
+        conditioning="phantom",
+        key=key,
+        batch_size=100,
+    )
+
+    np.testing.assert_array_equal(
+        np.asarray(larger_batch.log_Z_samples),
+        np.asarray(unbatched.log_Z_samples),
+    )
+    np.testing.assert_array_equal(
+        np.asarray(larger_batch.H_samples),
+        np.asarray(unbatched.H_samples),
+    )
+
+
+@pytest.mark.parametrize("batch_size", [0, -1])
+def test_sample_evidence_mc_rejects_invalid_batch_sizes(batch_size):
+    results = _make_single_block_gamma_public_result()
+
+    with pytest.raises(ValueError, match="batch_size.*positive integer"):
+        results.sample_evidence_mc(
+            num_samples=10,
+            conditioning="phantom",
+            key=jax.random.PRNGKey(229),
+            batch_size=batch_size,
+        )
+
+
+def test_batched_summary_preserves_block_models_and_kish_gate():
+    plateau = _make_single_block_gamma_public_result()
+    active = plateau.sample_evidence_mc(
+        num_samples=128,
+        conditioning="phantom",
+        key=jax.random.PRNGKey(233),
+        batch_size=31,
+        C_min=20,
+    )
+    inactive = plateau.sample_evidence_mc(
+        num_samples=128,
+        conditioning="phantom",
+        key=jax.random.PRNGKey(233),
+        batch_size=31,
+        C_min=21,
+    )
+    singleton = _make_result_case().results.sample_evidence_mc(
+        num_samples=32,
+        conditioning="phantom",
+        key=jax.random.PRNGKey(239),
+        batch_size=7,
+        C_min=1,
+    )
+    classic = _make_padded_plateau_result(0).sample_evidence_mc(
+        num_samples=9,
+        conditioning="classic",
+        key=jax.random.PRNGKey(241),
+        batch_size=1,
+    )
+
+    assert bool(np.asarray(active.phantom_gate_active)[0])
+    assert not bool(np.asarray(inactive.phantom_gate_active)[0])
+    assert float(np.asarray(active.p_eq_mean)[0]) > 0.0
+    np.testing.assert_array_equal(
+        np.asarray(singleton.p_eq_mean),
+        np.zeros_like(np.asarray(singleton.p_eq_mean)),
+    )
+    np.testing.assert_array_equal(
+        np.asarray(classic.phantom_gate_active),
+        np.zeros_like(np.asarray(classic.phantom_gate_active), dtype=bool),
+    )
+
+
+def test_full_diagnostics_support_a_partial_final_batch():
+    results = _make_single_block_gamma_public_result()
+
+    samples = results.sample_evidence_mc(
+        num_samples=10,
+        conditioning="phantom",
+        key=jax.random.PRNGKey(251),
+        batch_size=4,
+        diagnostics=True,
+    )
+
+    assert samples.p_gt_samples.shape == (10, 1)
+    assert samples.p_eq_samples.shape == (10, 1)
+    assert samples.p_lt_samples.shape == (10, 1)
+    assert samples.phantom_add_gt_samples.shape == (10, 1)
+
+
+def test_legacy_sample_evidence_uses_the_bounded_default():
+    results = _make_single_block_gamma_public_result()
+    key = jax.random.PRNGKey(257)
+
+    default = results.sample_evidence(num_samples=100, key=key)
+    explicit = results.sample_evidence(
+        num_samples=100,
+        batch_size=64,
+        key=key,
+    )
+
+    np.testing.assert_array_equal(np.asarray(default), np.asarray(explicit))
+
+
 def test_results_sample_mc_shrinkage_matches_explicit_block_state_public_call():
     results = _make_single_block_gamma_public_result()
     block_state = results_module._block_state_from_results(results)


### PR DESCRIPTION
Closes #249.
Closes #256.

## What changed

- Streams final Monte Carlo shrinkage in one jitted device scan with a vmapped draw batch, a sparse phantom-event plan prepared once, and online `[G]` sufficient-statistic carries.
- Makes `batch_size` a real memory-control contract on `State` and `NestedSamplerResults`; the evidence-facing default is an evidence-backed 64 draws.
- Keeps one shared `Gamma(1, 1)` weight per chain cluster and draw across all states/blocks, with the existing singleton two-class and plateau three-class laws unchanged.
- Makes full `[M, G]` probability/phantom-addition diagnostics opt-in via `diagnostics=True`; the default retains `[M]` evidence/entropy draws and `[G]` summaries.
- Audits all runtime dependencies. Matplotlib moves to a lazy `plotting` extra; JAX selects JAXLIB; stale ZMQ and nonexistent fabric entry points are removed. TFP, SciPy, JAXCTX, and NumPy remain base for documented public workflows.
- Changes the maintained demo workflow to install base JAXNS, so it detects undeclared runtime dependencies.

## Scientific correctness

- Final complete suite: **224 passed** in 487.41 s.
- The unchanged `tests/test_ns_standard_problems.py` release gate passes all **20** phantom-off/on cases without tolerance changes.
- Fixed-key calls are deterministic. A batch at least as large as the ensemble is bit-for-bit identical to the original single-batch key path; independently keyed batched/unbatched ensembles agree at explicit MC moment tolerances.
- Focused tests cover batch size 1, final partial batches, batches at least `M`, invalid sizes, singleton/plateau laws, Kish gate on/off, classic no-phantom mode, economical output, and opt-in full diagnostics.
- The existing [30-seed-per-problem v2/current accuracy matrix](https://github.com/Joshuaalbert/jaxns/blob/develop/benchmarks/issue_247/REPORT.md) remains the release-calibration evidence. This PR changes streaming of draws from that model, not the model. The full implementation evidence is in [`benchmarks/issue_249/REPORT.md`](benchmarks/issue_249/REPORT.md).

## Final-MC performance

Paired against exact parent `develop@cb17efc`, CPU float64, JAX/JAXLIB 0.10.0, seed 0, 1,000 phantom-conditioned draws, identical completed states. First includes compile and execution; steady is median of five synchronized repetitions with IQR.

| problem | source | first s | steady median [IQR] s | peak RSS MiB |
|---|---|---:|---:|---:|
| basic MVN | develop | 8.739 | 6.432 [6.330, 6.733] | 3,018.9 |
| basic MVN | bounded 64 | 7.095 | 4.483 [4.399, 5.394] | 825.1 |
| spike-slab 8D | develop | 9.389 | 5.961 [5.946, 5.973] | 2,986.1 |
| spike-slab 8D | bounded 64 | 6.337 | 4.064 [3.853, 4.167] | 840.3 |
| spike-slab 10D | develop | 11.499 | 8.752 [8.708, 8.914] | 4,277.3 |
| spike-slab 10D | bounded 64 | 8.519 | 5.661 [5.604, 5.737] | 990.3 |

This is a **72.7%, 71.9%, and 76.8% peak-RSS reduction**, a **30.3%, 31.8%, and 35.3% steady speedup**, and an **18.8%, 32.5%, and 25.9% first-call speedup** respectively.

The basic-MVN compiler comparison reports output memory falling from 277.68 to 0.78 MiB and temporary memory from 2,055.77 to 151.60 MiB. The deterministic sparse plan still contains one sort and 14 scatters; the two added while calls are the bounded scan. Classic-only basic-MVN also improves: steady median 0.860 to 0.523 s, first 4.272 to 2.354 s, and peak RSS 1,157.4 to 664.0 MiB.

## Dependency evidence

- Final wheel: 113,385 bytes; metadata inspected directly. Base `Requires-Dist` is JAX, JAXCTX, NumPy, SciPy, and TFP-nightly, with exact `plotting`, `examples`, and `tests` extras and no fabric entry points. The test extra includes TOMLI only on Python 3.10, where the standard-library `tomllib` is unavailable.
- Clean base-wheel import plus real local nested-sampling demo passes on Python **3.10, 3.11, 3.12, 3.13, and 3.14**. Matplotlib is absent in every base environment and JAX resolves a matching JAXLIB in every environment.
- `jaxns[plotting]` writes a plot under Agg; `jaxns[examples]` imports Matplotlib, Optax, and scikit-learn. Missing plotting support fails only when requested and names `jaxns[plotting]` as the remedy.
- Equivalent Python 3.12 environment size falls from 982 MiB to 752 MiB. The old install pulled the Matplotlib stack and the `zmq` shim/PyZMQ for nonexistent distributed entry points.

## Performance and code-intent review

Ran `performance-and-intent-review-flow` over Python orchestration, tracing/static boundaries, device execution, pytrees, HLO, compiler memory, numerical behavior, and comments.

Two findings were fixed before the final measurements:

1. The first scan stacked one `[G]` summary per batch, which would recreate `[M, G]` at `batch_size=1`; summaries now stay in online `[G]` carries.
2. The provisional 256 default was dominated after that fix; a 32/64/128/256 sweep selected 64 as the measured runtime/memory knee.

There are no remaining blocking findings. Residuals are explicit: full diagnostics necessarily retain their requested `[M, G]` output; draw/batch shape changes may compile a new specialization; and the recorded performance comparison is CPU-only. Replacement sampling remains a full `vmap`; the new scan applies only to independent final evidence draws and introduces no `lax.map`.

## Verification

- `pytest -q`: 224 passed
- `pytest -q cicd/reviewer_autochecks`: 4 passed
- focused Ruff: pass
- flake8 syntax/undefined-name pass: 0 findings
- final wheel build and metadata inspection: pass
- five-version clean base install/import/demo matrix: pass
