### PR TITLE
Start the maintained JAXNS v2.7 release line

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -5,9 +5,12 @@ name: Python package
 
 on:
   pull_request:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "develop", "v2" ]
   push:
-    branches: [ "main" ]
+    branches: [ "main", "v2" ]
+
+env:
+  MPLBACKEND: Agg
 
 jobs:
   build:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-requirements.txt
-requirements-*.txt
+include requirements.txt
+include requirements-*.txt

--- a/README.md
+++ b/README.md
@@ -359,6 +359,10 @@ before importing JAXNS.
 
 # Change Log
 
+25 Aug, 2026 -- JAXNS 2.7.0 maintenance line started from the published 2.6.9 source. This branch will continue to
+receive compatible v2 fixes for users who are not upgrading to v3. Fixed source distributions to include the
+requirement files needed for installation.
+
 7 Dec, 2024 -- JAXNS 2.6.7 released. Fix pip dependencies install.
 
 13 Nov, 2024 -- JAXNS 2.6.6 released. Minor improvements to plotting.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@
 project = "jaxns"
 copyright = "2024, Joshua G. Albert"
 author = "Joshua G. Albert"
-release = "2.6.9"
+release = "2.7.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jaxns"
-version = "2.6.9"
+version = "2.7.0"
 description = "Nested Sampling in JAX"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

- start the maintained JAXNS v2.7 release line from the exact source commit for
  the published `jaxns==2.6.9` package
- bump the package and documentation versions to 2.7.0
- document the maintained V2 line in the README changelog
- enable the existing test workflow for the `v2` branch and force Matplotlib's
  non-interactive `Agg` backend
- fix the existing V2 source-distribution manifest so requirement files needed
  by `setup.py` are included

This PR contains no V3 implementation code and makes no benchmark changes. The
existing V2 benchmarks remain the release evidence for now.

## Verified branch point

The permanent `v2` branch points at
`2f356d6d497ce3ac471fb9a06f9d22587487aaaa`, the final V2 commit on `main`.
The full `src/jaxns` tree and packaging metadata at that commit are byte-for-byte
identical to the published PyPI 2.6.9 source archive (SHA-256
`3b72e9dd27c6fdefdc86247b8d3a5cbd20d86cef69d5ac46e2528b78a44fdc11`).

## Verification

- `MPLBACKEND=Agg pytest -q`: 145 passed
- critical Flake8 checks: passed
- Ruff checks for the touched Python/TOML files: passed
- wheel and sdist build: passed; both report version 2.7.0
- rebuild a wheel from the generated sdist: passed
- generated sdist contains all four requirement files

Tracks #251.
