### PR TITLE
Keep custom goals at allocation boundaries

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -27,3 +27,6 @@ repeat mistakes specific to this project. Keep learnings compact.
 - Phantom clusters descended from one root race lineage are not independent
   after finite Markov transitions. Share their gamma weight; grouping only
   exact repeated seeds understated uncertainty on the 10D curved release gate.
+- Sample-buffer growth resumes an unfinished compiled depth epoch. Do not run
+  a custom scientific goal at that physical boundary; initial capacity must
+  not change the logical allocation round or stopping point.

--- a/cicd/non_invariant_test_coverage.json
+++ b/cicd/non_invariant_test_coverage.json
@@ -406,8 +406,8 @@
       "path": "cicd/tests/test_allocation.py",
       "reason": "implementation_formula"
     },
-    "test_public_data_objects_are_frozen_and_slotted": {
-      "note": "Checks the current compiled scheduler, append-order index, batching, or pytree architecture.",
+    "test_public_scientific_data_objects_are_frozen_and_slotted": {
+      "note": "Checks that mutable sampler configuration remains separate from frozen scientific state and result data.",
       "path": "cicd/tests/test_core.py",
       "reason": "architecture_boundary"
     },

--- a/cicd/reviewer_autochecks/test_repository_structure.py
+++ b/cicd/reviewer_autochecks/test_repository_structure.py
@@ -29,6 +29,13 @@ ARRAY_ANNOTATION_MARKERS = (
     "TreeField",
 )
 
+# NestedSampler is mutable user configuration: its constructor normalises
+# dependent defaults with ordinary assignments. Scientific arrays and sampler
+# state remain in the frozen dataclasses covered by the general rule below.
+MUTABLE_CONFIGURATION_DATACLASSES = {
+    ("src/jaxns/core.py", "NestedSampler"),
+}
+
 
 def _decorator_name(decorator: ast.expr) -> str:
     if isinstance(decorator, ast.Call):
@@ -117,9 +124,10 @@ def test_array_dataclass_fields_have_shape_comments() -> None:
     )
 
 
-def test_production_dataclasses_are_frozen_and_slotted() -> None:
-    """Scientific containers cannot be mutated or gain accidental fields."""
+def test_production_dataclasses_preserve_declared_mutability() -> None:
+    """Scientific containers stay frozen; declared configuration stays slotted."""
     invalid: list[str] = []
+    mutable_configuration_seen: set[tuple[str, str]] = set()
     for path in sorted(SOURCE_ROOT.rglob("*.py")):
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for class_node in (
@@ -127,17 +135,31 @@ def test_production_dataclasses_are_frozen_and_slotted() -> None:
             if isinstance(node, ast.ClassDef) and _is_dataclass(node)
         ):
             options = _dataclass_options(class_node)
+            relative_path = str(path.relative_to(REPO_ROOT))
+            class_key = (relative_path, class_node.name)
+            if class_key in MUTABLE_CONFIGURATION_DATACLASSES:
+                mutable_configuration_seen.add(class_key)
+                if (
+                    _is_literal_true(options.get("slots"))
+                    and not _is_literal_true(options.get("frozen"))
+                ):
+                    continue
             if (
                 _is_literal_true(options.get("frozen"))
                 and _is_literal_true(options.get("slots"))
             ):
                 continue
             invalid.append(
-                f"{path.relative_to(REPO_ROOT)}:{class_node.lineno} "
+                f"{relative_path}:{class_node.lineno} "
                 f"{class_node.name}"
             )
 
+    assert mutable_configuration_seen == MUTABLE_CONFIGURATION_DATACLASSES, (
+        "Mutable configuration dataclass declarations are stale: "
+        f"{MUTABLE_CONFIGURATION_DATACLASSES - mutable_configuration_seen}"
+    )
     assert not invalid, (
-        "Production dataclasses must set frozen=True and slots=True:\n"
+        "Production dataclasses must be frozen and slotted unless explicitly "
+        "declared as mutable, slotted configuration:\n"
         + "\n".join(invalid)
     )

--- a/cicd/tests/test_core.py
+++ b/cicd/tests/test_core.py
@@ -614,7 +614,10 @@ def test_unlimited_growth_matches_preallocated_scientific_continuation():
     tiny = NestedSampler(initial_capacity=2, **common)
     preallocated = NestedSampler(initial_capacity=32, **common)
 
+    observed_goal_boundaries = []
+
     def goal(state):
+        observed_goal_boundaries.append(bool(state.depth_reached))
         return int(state.goal_loop_iter) >= 2
 
     key = jax.random.PRNGKey(34)
@@ -632,6 +635,9 @@ def test_unlimited_growth_matches_preallocated_scientific_continuation():
     # independent of those implementation-only boundaries.
     assert grown.samples.log_likelihoods.shape[0] == 8
     assert reference.samples.log_likelihoods.shape[0] == 32
+    # Resizing is an implementation detail inside one depth epoch. A custom
+    # scientific goal must only observe initial or completed depth boundaries.
+    assert all(observed_goal_boundaries)
     assert int(grown.goal_loop_iter) == int(reference.goal_loop_iter) == 2
     assert int(grown.num_samples) == int(reference.num_samples) == 5
     grown = grown.trim()
@@ -808,7 +814,7 @@ def test_ellipsoidal_state_survives_checkpoint_growth_and_resume():
         np.testing.assert_array_equal(np.asarray(left), np.asarray(right))
 
 
-def test_public_data_objects_are_frozen_and_slotted():
+def test_public_scientific_data_objects_are_frozen_and_slotted():
     ns = NestedSampler(
         model=make_toy_model(),
         target_num_live_points=2,
@@ -821,8 +827,14 @@ def test_public_data_objects_are_frozen_and_slotted():
     direction = EllipsoidalDirection()
     sampler_data = empty_sampler_data(num_components=1, dimension=1)
 
+    # NestedSampler is mutable configuration whose dependent defaults are
+    # normalised with ordinary typed assignments during construction. The
+    # scientific state it produces remains immutable.
+    assert hasattr(type(ns), "__slots__")
+    ns.store_phantom_samples = True
+    assert ns.store_phantom_samples
+
     for value, field_name in (
-        (ns, "max_samples"),
         (state, "num_samples"),
         (state.samples, "out_degree"),
         (direction, "num_components"),

--- a/src/jaxns/core.py
+++ b/src/jaxns/core.py
@@ -1112,7 +1112,7 @@ def _build_init_state(
     )
 
 
-@dataclasses.dataclass(slots=True, frozen=True)
+@dataclasses.dataclass(slots=True)
 class NestedSampler(PureDataclassPytree):
     """Object-oriented configuration and Python goal-loop driver.
 
@@ -1243,14 +1243,14 @@ class NestedSampler(PureDataclassPytree):
         if max_samples is not None:
             initial_capacity = min(initial_capacity, max_samples)
 
-        object.__setattr__(self, "target_num_live_points", root_degree)
-        object.__setattr__(self, "root_allocation_degree", root_degree)
-        object.__setattr__(self, "shell_size", int(shell_size))
-        object.__setattr__(self, "max_samples", max_samples)
-        object.__setattr__(self, "sampler", sampler)
-        object.__setattr__(self, "termination_condition", termination_condition)
-        object.__setattr__(self, "initial_capacity", initial_capacity)
-        object.__setattr__(self, "delta_K", int(delta_K))
+        self.target_num_live_points = root_degree
+        self.root_allocation_degree = root_degree
+        self.shell_size = int(shell_size)
+        self.max_samples = max_samples
+        self.sampler = sampler
+        self.termination_condition = termination_condition
+        self.initial_capacity = initial_capacity
+        self.delta_K = int(delta_K)
 
     @classmethod
     def flatten(cls, this) -> tuple[list[Any], tuple[Any, ...]]:
@@ -1380,7 +1380,13 @@ class NestedSampler(PureDataclassPytree):
             )
         while (
             int(state.termination_reason) == 0
-            and not bool(goal_cond(state))
+            # A resized sample buffer resumes the same compiled depth epoch.
+            # Only let the Python goal observe completed allocation rounds so
+            # physical capacity cannot change the scientific stopping point.
+            and (
+                not bool(state.depth_reached)
+                or not bool(goal_cond(state))
+            )
         ):
             state = _run_depth(
                 state,


### PR DESCRIPTION
## Summary

- make `NestedSampler` mutable configuration so dependent defaults use ordinary typed assignments instead of `object.__setattr__`
- keep scientific `State`, `Samples`, direction, and sampler-data objects frozen
- evaluate custom Python goals only at initial or completed depth boundaries, never while resuming the same epoch after physical sample-buffer growth
- add regressions for both contracts
- declare the one mutable configuration dataclass explicitly in reviewer autochecks; all other production dataclasses remain frozen and slotted

Related to #269.

The allocation-cadence experiment itself did not pass its mode-weight gate;
this PR intentionally contains none of the candidate allocation changes or
benchmark artifacts.

## Performance and intent

Both production changes are in Python construction/orchestration. They do not
alter `_run_depth`, JAX array shapes, compiled batching, numerical operations,
or the device hot path. The goal-boundary guard prevents an extra scientific
decision at a storage implementation boundary and makes the existing comment
about resuming the same allocation target executable as a tested invariant.

## Validation

- `MPLBACKEND=Agg PYTHONPATH=/tmp/jaxns-issue-269-fixes/src timeout 600s conda run -n jaxns_py pytest -q cicd/tests/test_core.py cicd/tests/test_distributed_core.py cicd/reviewer_autochecks` — 36 passed
- `conda run -n jaxns_py ruff check src/jaxns/core.py cicd/tests/test_core.py cicd/reviewer_autochecks/test_repository_structure.py`
- `conda run -n jaxns_py flake8 --ignore=E501,W503 src/jaxns/core.py cicd/tests/test_core.py cicd/reviewer_autochecks/test_repository_structure.py`
