### PR TITLE
Add automatic durable run checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+/checkpoints/
 
 # Translations
 *.mo

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -27,6 +27,9 @@ repeat mistakes specific to this project. Keep learnings compact.
 - Phantom clusters descended from one root race lineage are not independent
   after finite Markov transitions. Share their gamma weight; grouping only
   exact repeated seeds understated uncertainty on the 10D curved release gate.
+- Automatic checkpoints are opt-in full `State` or `DistributedState` Pytree
+  saves. The checkpoint layer owns atomic publication and corruption detection;
+  callers own model, arguments, sampler, and runner compatibility on resume.
 - Sample-buffer growth resumes an unfinished compiled depth epoch. Do not run
   a custom scientific goal at that physical boundary; initial capacity must
   not change the logical allocation round or stopping point.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,30 @@ state = sampler.run_until_goal(
 )
 ```
 
+Long runs can opt into automatic full-state checkpoints. The default cadence
+is one hour, checked between completed depth epochs. A changed final state is
+also saved, and invoking the same run again with the same directory resumes
+the committed random stream automatically:
+
+```python
+state = sampler.run_until_goal(
+    goal_cond=goal_cond,
+    key=jax.random.PRNGKey(3),
+    checkpoint_dir="checkpoints/science-run",
+    checkpoint_cadence=3600.0,
+)
+```
+
+Each state is written through the ordinary Pytree serialization surface and
+published atomically through a checksum-bearing `CHECKPOINT` manifest. JAXNS
+rejects incomplete or corrupted storage before deserialization. Checkpoint
+directories contain trusted Python pickle data; use them only with the model,
+arguments, sampler, and environment appropriate for that scientific run.
+One process holds the directory lock for the complete run. The newest two
+generations are retained, but corruption fails closed with
+`CheckpointCorruptionError` rather than silently rolling back; a competing
+writer receives `CheckpointInUseError`.
+
 The lightweight expectation estimates on `State` are suitable for frequent
 goal and depth decisions. Final user-facing evidence should be drawn with the
 Monte Carlo shrinkage model. Phantom conditioning is explicit, so the same run
@@ -301,6 +325,8 @@ distributed_sampler = DistributedNestedSampler(
 )
 checkpoint = distributed_sampler.run(
     key=jax.random.PRNGKey(7),
+    checkpoint_dir="checkpoints/distributed-run",
+    checkpoint_cadence=3600.0,
 )
 results = checkpoint.to_result().trim()
 results.summary()
@@ -367,6 +393,8 @@ requests.
 - Added race-tree nested sampling with dynamic lineage allocation, a Python
   user-goal loop, JIT-compiled depth epochs, and continuation-batched
   likelihood evaluation across replacement chains.
+- Added opt-in, hourly full-state checkpoints with automatic local and
+  distributed resume, atomic manifest publication, and corruption detection.
 - Made model data and parameters explicit through JAXCTX `args` and `params`,
   and made scientific state and result objects immutable pytree dataclasses.
 - Added plateau-correct shrinkage and bounded final Monte Carlo evidence draws,

--- a/benchmarks/issue_270/REPORT.md
+++ b/benchmarks/issue_270/REPORT.md
@@ -1,0 +1,53 @@
+# Issue 270 Checkpoint Evidence
+
+## Question
+
+Does adding opt-in automatic full-state checkpointing change ordinary run
+performance, and is one full checkpoint per hour a material cost?
+
+## Method
+
+`run_checkpoint.py` was run in separate Python processes against baseline
+commit `7c34ca7` and this branch. Both used Python 3.12.9, JAX/JAXLIB 0.10.0,
+x64, and one CPU device.
+
+The disabled-path comparison used the public `NestedSampler.run_until_goal`
+path with no checkpoint directory. The deterministic workload had eight
+dimensions, root degree 16, replacement width 8, and physical capacity 256.
+Compilation was warmed before 200 measured runs per version. Each paired seed
+produced the same valid count, root degree, and summed likelihood signature.
+
+The opt-in measurement saved an actual complete `State` enlarged to physical
+capacity 1,000,000. Each save included Pytree pickle serialization, file
+fsync, SHA-256, atomic state publication, directory fsync, atomic manifest
+publication, and old-generation pruning. Five generations were measured on
+the local filesystem.
+
+## Results
+
+| Measurement | Baseline | Branch | Branch / baseline |
+|---|---:|---:|---:|
+| Compile + first run | 1.74044 s | 1.74059 s | 1.00009 |
+| Steady median, 200 runs | 3.335 ms | 3.275 ms | 0.9820 |
+| Steady mean, 200 runs | 3.335 ms | 3.309 ms | 0.9923 |
+| Scientific signatures | exact | exact | — |
+
+There is no measured regression when `checkpoint_dir` is omitted. The JAX
+depth program itself is unchanged; the disabled path adds only host-side
+optional-argument routing at the outer boundary.
+
+The 1,000,000-capacity state occupied 104,001,927 bytes. Full atomic saves took
+0.5717–0.6172 seconds, with a 0.6014-second median. At one save per hour this
+is 0.0167% of wall time.
+
+## Interpretation
+
+The evidence supports the selected design: checkpointing remains entirely
+opt-in, the ordinary scientific path has no material performance change, and
+even a roughly 104 MB full state has negligible amortized cost at the default
+one-hour cadence. Filesystem behavior will differ on networked storage, so the
+measured absolute save time should not be treated as an NFS or parallel-filesystem
+claim; cadence remains user-configurable for those environments.
+
+Raw summary values are retained in `results.json`; the benchmark script emits
+full per-run timings when reproduced.

--- a/benchmarks/issue_270/results.json
+++ b/benchmarks/issue_270/results.json
@@ -1,0 +1,40 @@
+{
+  "date": "2026-08-28",
+  "baseline_commit": "7c34ca7",
+  "python": "3.12.9",
+  "jax": "0.10.0",
+  "jaxlib": "0.10.0",
+  "device": "cpu:0",
+  "x64": true,
+  "disabled_path": {
+    "repeats_per_version": 200,
+    "root_allocation_degree": 16,
+    "shell_size": 8,
+    "physical_capacity": 256,
+    "dimensions": 8,
+    "baseline_compile_and_first_run_seconds": 1.7404374489560723,
+    "branch_compile_and_first_run_seconds": 1.740593739086762,
+    "baseline_median_seconds": 0.003335175453685224,
+    "branch_median_seconds": 0.00327530805952847,
+    "median_ratio_branch_over_baseline": 0.9820497017359002,
+    "baseline_mean_seconds": 0.0033349413296673448,
+    "branch_mean_seconds": 0.003309287562733516,
+    "mean_ratio_branch_over_baseline": 0.992307580734445,
+    "all_scientific_signatures_exact": true
+  },
+  "checkpoint": {
+    "dimensions": 8,
+    "physical_capacity": 1000000,
+    "state_bytes": 104001927,
+    "save_seconds": [
+      0.6014408881310374,
+      0.5716654278803617,
+      0.6030775101389736,
+      0.6172457940410823,
+      0.6009946190752089
+    ],
+    "median_save_seconds": 0.6014408881310374,
+    "one_hour_wall_fraction": 0.0001670669133697326,
+    "one_hour_wall_percent": 0.01670669133697326
+  }
+}

--- a/benchmarks/issue_270/run_checkpoint.py
+++ b/benchmarks/issue_270/run_checkpoint.py
@@ -1,0 +1,189 @@
+"""Measure disabled-path runtime and opt-in full-state checkpoint cost."""
+# flake8: noqa
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import platform
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--measure-checkpoint", action="store_true")
+    parser.add_argument("--checkpoint-capacity", type=int, default=1_000_000)
+    return parser.parse_args()
+
+
+ARGS = _parse_args()
+sys.path.insert(0, str(ARGS.source.resolve()))
+
+import jax
+import jax.numpy as jnp
+import jaxlib
+
+from jaxns.constrained_sampler import AbstractSampler
+from jaxns.core import NestedSampler
+from jaxns.pytree import PureDataclassPytree
+from jaxns.samples import PhantomSamples, SeedPoint
+from jaxns.termination_condition import TerminationCondition
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class BenchmarkModel(PureDataclassPytree):
+    """Eight-dimensional model with a cheap likelihood."""
+
+    def U_ndims(self, args=(), params=None) -> int:
+        del args, params
+        return 8
+
+    def sample_U(self, key, args=(), params=None):
+        del args, params
+        return jax.random.uniform(key, shape=(8,))
+
+    def transform_to_X(self, U, args=(), params=None):
+        del args, params
+        return U
+
+    def log_likelihood(self, U, args=(), params=None, *, allow_nan=True):
+        del args, params, allow_nan
+        return -jnp.sum(jnp.square(U - 0.5))
+
+    def log_prior(self, U, args=(), params=None):
+        del args, params
+        return jnp.where(jnp.all((U >= 0.0) & (U <= 1.0)), 0.0, -jnp.inf)
+
+
+BenchmarkModel.register_pytree()
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class BenchmarkSampler(PureDataclassPytree, AbstractSampler):
+    """Cheap sampler isolating Python run/checkpoint orchestration."""
+
+    def num_phantom(self) -> int:
+        return 0
+
+    def get_sample(
+            self,
+            key,
+            log_L_constraint,
+            seed_point: SeedPoint,
+            args=(),
+            params=None,
+    ):
+        del key, args, params
+        finite = jnp.where(
+            jnp.isfinite(log_L_constraint),
+            log_L_constraint,
+            0.0,
+        )
+        return (
+            seed_point.U0,
+            finite + 1.0,
+            jnp.asarray(1, dtype=jnp.int32),
+            PhantomSamples(
+                U_samples=jnp.zeros((0, 8)),
+                valid_mask=jnp.zeros((0,), dtype=bool),
+                log_L=jnp.zeros((0,)),
+            ),
+        )
+
+
+BenchmarkSampler.register_pytree()
+
+
+model = BenchmarkModel()
+runner = NestedSampler(
+    model=model,
+    root_allocation_degree=16,
+    shell_size=8,
+    max_samples=256,
+    initial_capacity=256,
+    sampler=BenchmarkSampler(),
+    termination_condition=TerminationCondition(max_samples=256),
+)
+
+
+def goal(state):
+    return int(state.goal_loop_iter) >= 3
+
+
+compile_start = time.perf_counter()
+warm_state = runner.run_until_goal(goal, key=jax.random.PRNGKey(0))
+jax.block_until_ready(warm_state)
+compile_and_first_run_seconds = time.perf_counter() - compile_start
+
+run_seconds = []
+signatures = []
+for repeat in range(ARGS.repeats):
+    start = time.perf_counter()
+    state = runner.run_until_goal(
+        goal,
+        key=jax.random.PRNGKey(repeat + 1),
+    )
+    jax.block_until_ready(state)
+    run_seconds.append(time.perf_counter() - start)
+    signatures.append((
+        int(state.num_samples),
+        int(state.root_out_degree),
+        float(jnp.sum(state.samples.log_likelihoods[:state.num_samples])),
+    ))
+
+checkpoint = None
+if ARGS.measure_checkpoint:
+    from jaxns.checkpoint import CheckpointManager
+
+    # Capacity, rather than current valid count, dominates full-state bytes.
+    # This enlarged real State keeps the benchmark tied to the public Pytree
+    # schema while representing a materially longer scientific run.
+    checkpoint_state = warm_state.resize(ARGS.checkpoint_capacity)
+    jax.block_until_ready(checkpoint_state)
+    checkpoint_seconds = []
+    with tempfile.TemporaryDirectory() as directory:
+        with CheckpointManager(directory) as manager:
+            for _ in range(5):
+                start = time.perf_counter()
+                manager.save(checkpoint_state)
+                checkpoint_seconds.append(time.perf_counter() - start)
+        manifest = json.loads(
+            (Path(directory) / "CHECKPOINT").read_text(encoding="utf-8")
+        )
+        state_bytes = (Path(directory) / manifest["state_file"]).stat().st_size
+    checkpoint = {
+        "capacity": ARGS.checkpoint_capacity,
+        "state_bytes": state_bytes,
+        "seconds": checkpoint_seconds,
+        "median_seconds": statistics.median(checkpoint_seconds),
+        "hourly_wall_fraction": statistics.median(checkpoint_seconds) / 3600.0,
+    }
+
+result = {
+    "source": str(ARGS.source.resolve()),
+    "python": platform.python_version(),
+    "jax": jax.__version__,
+    "jaxlib": jaxlib.__version__,
+    "device": str(jax.devices()[0]),
+    "x64": bool(jax.config.x64_enabled),
+    "compile_and_first_run_seconds": compile_and_first_run_seconds,
+    "run_seconds": run_seconds,
+    "median_run_seconds": statistics.median(run_seconds),
+    "signatures": signatures,
+    "checkpoint": checkpoint,
+}
+ARGS.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+print(json.dumps({
+    "output": str(ARGS.output),
+    "compile_and_first_run_seconds": compile_and_first_run_seconds,
+    "median_run_seconds": result["median_run_seconds"],
+    "checkpoint": checkpoint,
+}, indent=2))

--- a/cicd/coverage_record.json
+++ b/cicd/coverage_record.json
@@ -127,7 +127,23 @@
   ],
   "Resuming a state with its stored random-stream position is scientifically equivalent to uninterrupted continuation under the same conditions.": [
     "test_resume_uses_stored_key_and_matches_uninterrupted_run",
-    "test_unlimited_growth_matches_preallocated_scientific_continuation"
+    "test_unlimited_growth_matches_preallocated_scientific_continuation",
+    "test_local_automatic_resume_matches_uninterrupted_random_stream"
+  ],
+  "Automatic checkpoint resume restores exactly the last committed full run state, including its random stream and any retry-stable distributed work.": [
+    "test_checkpoint_round_trip_publishes_manifest_after_complete_state",
+    "test_local_automatic_resume_matches_uninterrupted_random_stream",
+    "test_run_single_iteration_automatically_loads_and_advances_checkpoint",
+    "test_complete_distributed_pending_state_round_trips_without_task_loss",
+    "test_real_pool_runs_scalar_vmap_retries_and_cli_lifecycle"
+  ],
+  "An interrupted or corrupted checkpoint cannot be accepted as a valid run state, and corrupted state bytes are rejected before deserialization.": [
+    "test_checksum_mismatch_fails_closed_before_deserialization",
+    "test_interrupted_state_write_preserves_previous_commit",
+    "test_interrupted_manifest_publication_preserves_previous_commit",
+    "test_missing_manifest_with_state_file_is_incomplete_checkpoint",
+    "test_malformed_manifest_fails_before_state_lookup",
+    "test_missing_state_file_and_unsupported_schema_fail_clearly"
   ],
   "A state contains all scientific data and random-stream position needed to continue its run without hidden mutable sampler state.": [
     "test_ellipsoidal_state_survives_checkpoint_growth_and_resume"
@@ -205,7 +221,8 @@
   ],
   "A resumable distributed checkpoint identifies every outstanding logical sample and its random stream without treating an unreturned sample as an observed race-tree arrival.": [
     "test_distributed_checkpoint_preserves_unreturned_task_and_keys",
-    "test_submit_failure_exposes_newest_resumable_checkpoint"
+    "test_submit_failure_exposes_newest_resumable_checkpoint",
+    "test_complete_distributed_pending_state_round_trips_without_task_loss"
   ],
   "A completed distributed state exposed to a user contains no provisional lineage or uncommitted sampling work.": [
     "test_reservations_are_planning_data_until_once_only_acceptance",

--- a/cicd/non_invariant_test_coverage.json
+++ b/cicd/non_invariant_test_coverage.json
@@ -671,6 +671,21 @@
       "path": "cicd/tests/test_distributed_runtime.py",
       "reason": "runtime_architecture"
     },
+    "test_checkpoint_cadence_uses_monotonic_seconds_and_retains_two_generations": {
+      "note": "Checks the selected one-hour monotonic cadence and two-generation retention policy.",
+      "path": "cicd/tests/test_checkpoint.py",
+      "reason": "checkpoint_implementation"
+    },
+    "test_checkpoint_cadence_rejects_invalid_seconds": {
+      "note": "Checks fail-fast validation for the public cadence unit and finite-value contract.",
+      "path": "cicd/tests/test_checkpoint.py",
+      "reason": "configuration_contract"
+    },
+    "test_checkpoint_directory_has_one_writer_for_whole_run": {
+      "note": "Checks the concrete advisory-lock implementation used to exclude concurrent checkpoint writers.",
+      "path": "cicd/tests/test_checkpoint.py",
+      "reason": "checkpoint_implementation"
+    },
     "test_supervisor_rotates_dispatch_fairly_between_sessions": {
       "note": "Checks the selected supervisor round-robin queue policy between active clients.",
       "path": "cicd/tests/test_distributed_runtime.py",

--- a/cicd/tests/test_checkpoint.py
+++ b/cicd/tests/test_checkpoint.py
@@ -1,0 +1,395 @@
+"""Durability and automatic-resume contracts for run checkpoints."""
+
+import dataclasses
+import json
+import multiprocessing
+import os
+from pathlib import Path
+
+import jax
+import numpy as np
+import pytest
+from jax import numpy as jnp
+
+import jaxns.checkpoint as checkpoint_module
+from cicd.tests.core_fixtures import make_state
+from cicd.tests.distributed_support import make_toy_model
+from jaxns.checkpoint import (
+    CHECKPOINT_CADENCE_SECONDS,
+    CheckpointCorruptionError,
+    CheckpointInUseError,
+    CheckpointManager,
+)
+from jaxns.constrained_sampler import (
+    ConstrainedSampleRequest,
+    UniDimSliceSampler,
+)
+from jaxns.core import CoreWorkBatch, NestedSampler
+from jaxns.distributed_core import (
+    DistributedState,
+    PendingTask,
+    ReservationState,
+)
+from jaxns.pytree import PureDataclassPytree, Pytree
+from jaxns.samples import SeedPoint
+from jaxns.termination_condition import TerminationCondition
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class CheckpointValue(PureDataclassPytree):
+    """Small complete Pytree used to isolate filesystem behavior."""
+
+    value: jax.Array  # []
+
+
+CheckpointValue.register_pytree()
+
+
+class ManualClock:
+    """Controllable monotonic clock for cadence tests."""
+
+    __slots__ = ("seconds",)
+
+    def __init__(self) -> None:
+        self.seconds = 0.0
+
+    def __call__(self) -> float:
+        return self.seconds
+
+
+def _value(value: int) -> CheckpointValue:
+    return CheckpointValue(jnp.asarray(value, dtype=jnp.int32))
+
+
+def _manifest(checkpoint_dir: Path) -> dict[str, object]:
+    return json.loads(
+        (checkpoint_dir / "CHECKPOINT").read_text(encoding="utf-8")
+    )
+
+
+def _assert_same_tree(left, right) -> None:
+    assert jax.tree.structure(left) == jax.tree.structure(right)
+    for left_leaf, right_leaf in zip(
+        jax.tree.leaves(left),
+        jax.tree.leaves(right),
+        strict=True,
+    ):
+        np.testing.assert_array_equal(
+            np.asarray(left_leaf),
+            np.asarray(right_leaf),
+        )
+
+
+def _attempt_checkpoint_lock(checkpoint_dir: str, outcomes) -> None:
+    try:
+        with CheckpointManager[CheckpointValue](checkpoint_dir):
+            outcomes.put("acquired")
+    except CheckpointInUseError:
+        outcomes.put("blocked")
+
+
+def test_checkpoint_round_trip_publishes_manifest_after_complete_state(
+        tmp_path,
+):
+    state = _value(7)
+    with CheckpointManager[CheckpointValue](tmp_path) as manager:
+        manager.save(state)
+
+    manifest = _manifest(tmp_path)
+    assert manifest["schema_version"] == 1
+    assert manifest["generation"] == 1
+    assert manifest["checksum_algorithm"] == "sha256"
+    assert len(manifest["checksum"]) == 64
+    assert (tmp_path / manifest["state_file"]).is_file()
+
+    with CheckpointManager[CheckpointValue](tmp_path) as manager:
+        restored = manager.load()
+    _assert_same_tree(restored, state)
+
+
+def test_checkpoint_cadence_uses_monotonic_seconds_and_retains_two_generations(
+        tmp_path,
+):
+    clock = ManualClock()
+    with CheckpointManager[CheckpointValue](
+        tmp_path,
+        cadence_seconds=CHECKPOINT_CADENCE_SECONDS,
+        clock=clock,
+    ) as manager:
+        clock.seconds = CHECKPOINT_CADENCE_SECONDS - 1.0
+        assert not manager.maybe_save(_value(1))
+        clock.seconds = CHECKPOINT_CADENCE_SECONDS
+        assert manager.maybe_save(_value(1))
+        clock.seconds = 2.0 * CHECKPOINT_CADENCE_SECONDS
+        assert manager.maybe_save(_value(2))
+        clock.seconds = 3.0 * CHECKPOINT_CADENCE_SECONDS
+        assert manager.maybe_save(_value(3))
+
+    generations = sorted(tmp_path.glob("state-*.pkl"))
+    assert [path.name for path in generations] == [
+        "state-00000000000000000002.pkl",
+        "state-00000000000000000003.pkl",
+    ]
+
+
+def test_checksum_mismatch_fails_closed_before_deserialization(
+        tmp_path,
+        monkeypatch,
+):
+    with CheckpointManager[CheckpointValue](tmp_path) as manager:
+        manager.save(_value(1))
+        manager.save(_value(2))
+    manifest = _manifest(tmp_path)
+    state_path = tmp_path / manifest["state_file"]
+    state_path.write_bytes(state_path.read_bytes() + b"corruption")
+
+    deserialized = []
+
+    def forbidden_load(filename):
+        deserialized.append(filename)
+        raise AssertionError("Corrupted bytes reached pickle.load.")
+
+    monkeypatch.setattr(Pytree, "load", staticmethod(forbidden_load))
+    with (
+        CheckpointManager[CheckpointValue](tmp_path) as manager,
+        pytest.raises(CheckpointCorruptionError, match="checksum mismatch"),
+    ):
+        manager.load()
+    assert not deserialized
+    # The prior generation is retained for explicit operator recovery, but a
+    # corrupt newest commit never causes a silent scientific rollback.
+    assert len(tuple(tmp_path.glob("state-*.pkl"))) == 2
+
+
+def test_interrupted_state_write_preserves_previous_commit(
+        tmp_path,
+        monkeypatch,
+):
+    first = _value(1)
+    with CheckpointManager[CheckpointValue](tmp_path) as manager:
+        manager.save(first)
+
+        def interrupted_save(self, filename):
+            del self
+            Path(filename).write_bytes(b"partial pickle")
+            raise OSError("injected state interruption")
+
+        with monkeypatch.context() as patcher:
+            patcher.setattr(CheckpointValue, "save", interrupted_save)
+            with pytest.raises(OSError, match="state interruption"):
+                manager.save(_value(2))
+
+    assert not tuple(tmp_path.glob(".*.tmp.pkl"))
+    with CheckpointManager[CheckpointValue](tmp_path) as manager:
+        restored = manager.load()
+    _assert_same_tree(restored, first)
+
+
+def test_interrupted_manifest_publication_preserves_previous_commit(
+        tmp_path,
+        monkeypatch,
+):
+    first = _value(1)
+    with CheckpointManager[CheckpointValue](tmp_path) as manager:
+        manager.save(first)
+        replace = os.replace
+
+        def interrupt_manifest(source, target):
+            if Path(target).name == "CHECKPOINT":
+                raise OSError("injected manifest interruption")
+            replace(source, target)
+
+        with monkeypatch.context() as patcher:
+            patcher.setattr(
+                checkpoint_module.os,
+                "replace",
+                interrupt_manifest,
+            )
+            with pytest.raises(OSError, match="manifest interruption"):
+                manager.save(_value(2))
+
+    with CheckpointManager[CheckpointValue](tmp_path) as manager:
+        restored = manager.load()
+    _assert_same_tree(restored, first)
+
+
+def test_missing_manifest_with_state_file_is_incomplete_checkpoint(tmp_path):
+    (tmp_path / "state-00000000000000000001.pkl").write_bytes(b"partial")
+    with (
+        CheckpointManager[CheckpointValue](tmp_path) as manager,
+        pytest.raises(CheckpointCorruptionError, match="without a committed"),
+    ):
+        manager.load()
+
+
+def test_malformed_manifest_fails_before_state_lookup(tmp_path):
+    (tmp_path / "CHECKPOINT").write_text("{not-json", encoding="utf-8")
+    with (
+        CheckpointManager[CheckpointValue](tmp_path) as manager,
+        pytest.raises(CheckpointCorruptionError, match="valid UTF-8 JSON"),
+    ):
+        manager.load()
+
+
+def test_missing_state_file_and_unsupported_schema_fail_clearly(tmp_path):
+    manifest_path = tmp_path / "CHECKPOINT"
+    manifest_path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "generation": 1,
+            "state_file": "state-00000000000000000001.pkl",
+            "checksum_algorithm": "sha256",
+            "checksum": "0" * 64,
+        }),
+        encoding="utf-8",
+    )
+    with (
+        CheckpointManager[CheckpointValue](tmp_path) as manager,
+        pytest.raises(CheckpointCorruptionError, match="is missing"),
+    ):
+        manager.load()
+
+    manifest = _manifest(tmp_path)
+    manifest["schema_version"] = 2
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    with (
+        CheckpointManager[CheckpointValue](tmp_path) as manager,
+        pytest.raises(CheckpointCorruptionError, match="schema version"),
+    ):
+        manager.load()
+
+
+def test_checkpoint_directory_has_one_writer_for_whole_run(tmp_path):
+    context = multiprocessing.get_context("spawn")
+    outcomes = context.Queue()
+    with CheckpointManager[CheckpointValue](tmp_path):
+        process = context.Process(
+            target=_attempt_checkpoint_lock,
+            args=(str(tmp_path), outcomes),
+        )
+        process.start()
+        process.join(timeout=15.0)
+    assert not process.is_alive()
+    assert process.exitcode == 0
+    outcome = outcomes.get(timeout=1.0)
+    outcomes.close()
+    outcomes.join_thread()
+    assert outcome == "blocked"
+
+
+@pytest.mark.parametrize("cadence", [-1.0, float("nan"), float("inf")])
+def test_checkpoint_cadence_rejects_invalid_seconds(tmp_path, cadence):
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        CheckpointManager[CheckpointValue](tmp_path, cadence_seconds=cadence)
+
+
+def test_local_automatic_resume_matches_uninterrupted_random_stream(tmp_path):
+    model = make_toy_model()
+    sampler = UniDimSliceSampler(model=model, num_slices=2)
+    nested_sampler = NestedSampler(
+        model=model,
+        root_allocation_degree=2,
+        shell_size=1,
+        max_samples=10,
+        initial_capacity=4,
+        sampler=sampler,
+        termination_condition=TerminationCondition(max_samples=10),
+    )
+
+    def first_goal(state):
+        return int(state.goal_loop_iter) >= 1
+
+    def final_goal(state):
+        return int(state.goal_loop_iter) >= 3
+
+    key = jax.random.PRNGKey(17)
+    uninterrupted = nested_sampler.run_until_goal(final_goal, key=key)
+    nested_sampler.run_until_goal(
+        first_goal,
+        key=key,
+        checkpoint_dir=tmp_path,
+    )
+    resumed = nested_sampler.run_until_goal(
+        final_goal,
+        # A loaded checkpoint owns its continuation key.
+        key=jax.random.PRNGKey(999),
+        checkpoint_dir=tmp_path,
+    )
+
+    _assert_same_tree(resumed, uninterrupted)
+
+
+def test_run_single_iteration_automatically_loads_and_advances_checkpoint(
+        tmp_path,
+):
+    model = make_toy_model()
+    nested_sampler = NestedSampler(
+        model=model,
+        root_allocation_degree=2,
+        shell_size=1,
+        max_samples=6,
+        initial_capacity=6,
+        sampler=UniDimSliceSampler(model=model, num_slices=2),
+    )
+    first = nested_sampler.run_single_iteration(
+        key=jax.random.PRNGKey(21),
+        checkpoint_dir=tmp_path,
+    )
+    expected = nested_sampler.run_single_iteration(first)
+    unrelated = nested_sampler.initialise(jax.random.PRNGKey(999))
+    resumed = nested_sampler.run_single_iteration(
+        unrelated,
+        checkpoint_dir=tmp_path,
+    )
+    _assert_same_tree(resumed, expected)
+
+
+def test_complete_distributed_pending_state_round_trips_without_task_loss(
+        tmp_path,
+):
+    state = make_state(
+        root_out_degree=2,
+        log_likelihoods=(0.0, 1.0),
+        out_degree=(0, 0),
+        max_samples=5,
+    )
+    request = ConstrainedSampleRequest(
+        keys=jax.random.split(jax.random.PRNGKey(31), 1),
+        valid=jnp.asarray([True]),
+        log_L_constraints=jnp.asarray([0.0]),
+        seed_points=SeedPoint(
+            U0=jnp.asarray([0.4]),
+            log_L0=jnp.asarray([0.0]),
+        ),
+        sampler_data=None,
+    )
+    task_work = CoreWorkBatch(
+        valid=jnp.asarray([True]),
+        parent_idx=jnp.asarray([0], dtype=jnp.int32),
+        log_L_constraint=jnp.asarray([0.0]),
+        seed_idx=jnp.asarray([1], dtype=jnp.int32),
+    )
+    reservations = ReservationState(
+        parent_delta=jnp.asarray([1, 0, 0, 0, 0], dtype=jnp.int32),
+        root_delta=jnp.asarray(0, dtype=jnp.int32),
+        num_reserved=jnp.asarray(1, dtype=jnp.int32),
+    )
+    distributed = DistributedState(
+        state=state,
+        reservations=reservations,
+        pending=(PendingTask(7, task_work, request),),
+        next_task_id=8,
+        session_id="checkpoint-session",
+        depth_active=True,
+        goal_key=jax.random.PRNGKey(32),
+    )
+
+    with CheckpointManager[DistributedState](tmp_path) as manager:
+        manager.save(distributed)
+    with CheckpointManager[DistributedState](tmp_path) as manager:
+        restored = manager.load()
+
+    _assert_same_tree(restored, distributed)
+    assert restored.pending[0].task_id == 7
+    assert restored.next_task_id == 8
+    assert int(restored.reservations.num_reserved) == 1

--- a/cicd/tests/test_distributed_runtime.py
+++ b/cicd/tests/test_distributed_runtime.py
@@ -944,12 +944,22 @@ def test_real_pool_runs_scalar_vmap_retries_and_cli_lifecycle(tmp_path):
             initial_capacity=8,
             sampler=sampler,
         )
+        checkpoint_dir = tmp_path / "distributed-checkpoint"
+        first_checkpoint = distributed.run_until_goal(
+            lambda state: int(state.goal_loop_iter) >= 1,
+            depth_cond=TerminationCondition(dlogZ=jnp.asarray(0.5)),
+            key=jax.random.PRNGKey(21),
+            checkpoint_dir=checkpoint_dir,
+        )
         checkpoint = distributed.run_until_goal(
             lambda state: int(state.goal_loop_iter) >= 2,
             depth_cond=TerminationCondition(dlogZ=jnp.asarray(0.5)),
-            key=jax.random.PRNGKey(21),
+            # The persisted state owns the exact continuation stream.
+            key=jax.random.PRNGKey(999),
+            checkpoint_dir=checkpoint_dir,
         )
 
+        assert int(first_checkpoint.state.goal_loop_iter) >= 1
         assert not checkpoint.pending
         assert int(checkpoint.reservations.num_reserved) == 0
         state = checkpoint.state

--- a/docs/design/INVARIANTS.md
+++ b/docs/design/INVARIANTS.md
@@ -152,6 +152,10 @@ The exact text following each `- Invariant:` prefix is the stable key used by
   its run without hidden mutable sampler state.
 - Invariant: Resuming a state with its stored random-stream position is scientifically
   equivalent to uninterrupted continuation under the same conditions.
+- Invariant: Automatic checkpoint resume restores exactly the last committed full run state,
+  including its random stream and any retry-stable distributed work.
+- Invariant: An interrupted or corrupted checkpoint cannot be accepted as a valid run state,
+  and corrupted state bytes are rejected before deserialization.
 - Invariant: The user-supplied goal condition is evaluated against complete immutable run states
   and determines successful user-goal termination.
 - Invariant: A depth condition bounds one allocation epoch without being reported as successful

--- a/docs/design/REQUIREMENTS.md
+++ b/docs/design/REQUIREMENTS.md
@@ -218,6 +218,34 @@ properties that must hold independently of implementation live in
 - Requirement: A result is built only after block capacity and lineage consistency have been
   validated over the valid sample prefix.
 
+## Automatic Checkpointing
+
+- Requirement: Local and distributed run, run-until-goal, explicit-resume, and single-depth run
+  entry points accept a checkpoint directory and a cadence in seconds; checkpointing performs no
+  filesystem operation when the directory is omitted.
+- Requirement: Automatic checkpointing is opt-in and defaults to a one-hour cadence when a
+  checkpoint directory is supplied. Cadence is checked only at coherent Python depth boundaries,
+  and a changed final state is saved regardless of elapsed cadence.
+- Requirement: A checkpoint serializes the entire `State` or `DistributedState` through the
+  shared `Pytree.save` surface. Model, arguments, sampler, and runner compatibility are the
+  caller's responsibility and are not fingerprinted or inferred by the checkpoint layer.
+- Requirement: A state generation is written to a same-directory temporary file, flushed and
+  fsynced, checksummed with SHA-256, and atomically published before a final atomic `CHECKPOINT`
+  manifest commit. The containing directory is fsynced at each publication boundary on platforms
+  that support directory fsync.
+- Requirement: Loading verifies the exact manifest schema and state checksum before
+  deserialization. Missing, malformed, unsupported, incomplete, and checksum-mismatched
+  checkpoints fail with an actionable error rather than silently starting or rolling back.
+- Requirement: The newest two state generations are retained, but recovery never silently falls
+  back from a corrupt committed generation to an older state.
+- Requirement: One process owns a checkpoint-directory lock for the complete run so two writers
+  cannot resume and publish competing continuations.
+- Requirement: A retryable distributed execution error checkpoints the complete
+  `DistributedState`, including pending task identities, immutable requests, and provisional
+  reservations, before exposing the error when checkpointing is enabled.
+- Requirement: Checkpoints use trusted Python pickle serialization and are recovery artifacts for
+  a compatible Python environment, not a safe untrusted-data or archival interchange format.
+
 ## Allocation And Seed Scheduling
 
 - Requirement: Supported allocation targets are uniform, evidence improving, and posterior

--- a/docs/design/interface/run_pattern.py
+++ b/docs/design/interface/run_pattern.py
@@ -55,7 +55,14 @@ local_state = local.run_until_goal(
     goal_cond=goal_cond,
     depth_cond=TerminationCondition(),
     key=jax.random.PRNGKey(1),
+    checkpoint_dir="checkpoints/local",
+    checkpoint_cadence=3600.0,
 )
+
+# Re-running this call with the same checkpoint directory loads the complete
+# last committed State automatically. Checkpoint integrity is verified before
+# pickle deserialization; compatible model and sampler configuration remain
+# the scientific caller's responsibility.
 
 
 # The opt-in distributed path uses a stack started separately with:
@@ -79,6 +86,8 @@ checkpoint: DistributedState = distributed.run_until_goal(
     goal_cond=goal_cond,
     depth_cond=TerminationCondition(),
     key=jax.random.PRNGKey(2),
+    checkpoint_dir="checkpoints/distributed",
+    checkpoint_cadence=3600.0,
 )
 
 # A checkpoint contains retry-stable pending tasks if execution was interrupted.
@@ -88,6 +97,8 @@ checkpoint = distributed.resume_until_goal(
     checkpoint,
     goal_cond=goal_cond,
     depth_cond=TerminationCondition(),
+    checkpoint_dir="checkpoints/distributed",
+    checkpoint_cadence=3600.0,
 )
 results = checkpoint.to_result()
 results.summary()

--- a/src/jaxns/checkpoint.py
+++ b/src/jaxns/checkpoint.py
@@ -1,0 +1,446 @@
+"""Durable, corruption-detecting persistence for complete run states."""
+
+from __future__ import annotations
+
+import dataclasses
+import errno
+import hashlib
+import json
+import math
+import os
+import time
+from collections.abc import Callable
+from pathlib import Path
+from types import TracebackType
+from typing import Generic, TypeVar, cast
+from uuid import uuid4
+
+from jaxns.logging import jaxns_logger
+from jaxns.pytree import Pytree
+
+CHECKPOINT_CADENCE_SECONDS = 3600.0
+CHECKPOINT_SCHEMA_VERSION = 1
+CHECKSUM_ALGORITHM = "sha256"
+MANIFEST_NAME = "CHECKPOINT"
+LOCK_NAME = "CHECKPOINT.lock"
+STATE_PREFIX = "state-"
+STATE_SUFFIX = ".pkl"
+RETAINED_GENERATIONS = 2
+
+
+class CheckpointError(RuntimeError):
+    """Base error for checkpoint persistence and recovery."""
+
+    __slots__ = ()
+
+
+class CheckpointCorruptionError(CheckpointError):
+    """A published checkpoint is incomplete, malformed, or corrupted."""
+
+    __slots__ = ()
+
+
+class CheckpointInUseError(CheckpointError):
+    """Another process already owns the checkpoint directory."""
+
+    __slots__ = ()
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class CheckpointManifest:
+    """Commit record that makes one durable state generation visible."""
+
+    schema_version: int
+    generation: int
+    state_file: str
+    checksum_algorithm: str
+    checksum: str
+
+    def to_json_bytes(self) -> bytes:
+        """Return the canonical on-disk representation."""
+        payload = {
+            "schema_version": self.schema_version,
+            "generation": self.generation,
+            "state_file": self.state_file,
+            "checksum_algorithm": self.checksum_algorithm,
+            "checksum": self.checksum,
+        }
+        return (
+            json.dumps(payload, sort_keys=True, separators=(",", ":"))
+            + "\n"
+        ).encode("utf-8")
+
+    @classmethod
+    def from_json_bytes(cls, data: bytes) -> CheckpointManifest:
+        """Parse and strictly validate the persisted manifest schema."""
+        try:
+            payload = json.loads(data.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise CheckpointCorruptionError(
+                "CHECKPOINT is not valid UTF-8 JSON. Restore a valid "
+                "checkpoint directory or remove it to begin a new run."
+            ) from exc
+        if type(payload) is not dict:
+            raise CheckpointCorruptionError(
+                "CHECKPOINT must contain one JSON object."
+            )
+        values = cast(dict[str, object], payload)
+        expected = {
+            "schema_version",
+            "generation",
+            "state_file",
+            "checksum_algorithm",
+            "checksum",
+        }
+        if set(values) != expected:
+            raise CheckpointCorruptionError(
+                "CHECKPOINT has an unsupported field schema."
+            )
+
+        schema_version = values["schema_version"]
+        generation = values["generation"]
+        state_file = values["state_file"]
+        checksum_algorithm = values["checksum_algorithm"]
+        checksum = values["checksum"]
+        if type(schema_version) is not int:
+            raise CheckpointCorruptionError(
+                "CHECKPOINT schema_version must be an integer."
+            )
+        if schema_version != CHECKPOINT_SCHEMA_VERSION:
+            raise CheckpointCorruptionError(
+                "Unsupported checkpoint schema version "
+                f"{schema_version}; this JAXNS build supports "
+                f"{CHECKPOINT_SCHEMA_VERSION}."
+            )
+        if type(generation) is not int or generation < 1:
+            raise CheckpointCorruptionError(
+                "CHECKPOINT generation must be a positive integer."
+            )
+        if type(state_file) is not str:
+            raise CheckpointCorruptionError(
+                "CHECKPOINT state_file must be a string."
+            )
+        expected_state_file = _state_name(generation)
+        if state_file != expected_state_file:
+            raise CheckpointCorruptionError(
+                "CHECKPOINT state_file does not match its generation."
+            )
+        if checksum_algorithm != CHECKSUM_ALGORITHM:
+            raise CheckpointCorruptionError(
+                "Unsupported checkpoint checksum algorithm "
+                f"{checksum_algorithm!r}."
+            )
+        if type(checksum) is not str or len(checksum) != 64:
+            raise CheckpointCorruptionError(
+                "CHECKPOINT checksum must be a SHA-256 hexadecimal digest."
+            )
+        if any(character not in "0123456789abcdef" for character in checksum):
+            raise CheckpointCorruptionError(
+                "CHECKPOINT checksum must be lowercase hexadecimal."
+            )
+        return cls(
+            schema_version=schema_version,
+            generation=generation,
+            state_file=state_file,
+            checksum_algorithm=checksum_algorithm,
+            checksum=checksum,
+        )
+
+
+StateType = TypeVar("StateType", bound=Pytree)
+
+
+class CheckpointManager(Generic[StateType]):
+    """Own one checkpoint directory for the lifetime of a run.
+
+    The manager intentionally does not validate model, arguments, sampler, or
+    runner compatibility. A caller that opts into automatic resume owns that
+    semantic contract; JAXNS verifies only storage integrity and schema.
+    """
+
+    __slots__ = (
+        "_cadence_seconds",
+        "_checkpoint_dir",
+        "_clock",
+        "_last_checkpoint_time",
+        "_lock_file",
+        "_manifest",
+        "_saved_state",
+    )
+
+    def __init__(
+            self,
+            checkpoint_dir: str | Path,
+            cadence_seconds: float = CHECKPOINT_CADENCE_SECONDS,
+            clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if not math.isfinite(cadence_seconds) or cadence_seconds < 0.0:
+            raise ValueError(
+                "checkpoint_cadence must be finite and non-negative."
+            )
+        self._checkpoint_dir = Path(checkpoint_dir)
+        self._cadence_seconds = float(cadence_seconds)
+        self._clock = clock
+        self._last_checkpoint_time = self._clock()
+        self._lock_file = None
+        self._manifest: CheckpointManifest | None = None
+        self._saved_state: StateType | None = None
+
+    def __enter__(self) -> CheckpointManager[StateType]:
+        self._checkpoint_dir.mkdir(parents=True, exist_ok=True)
+        lock_path = self._checkpoint_dir / LOCK_NAME
+        lock_file = lock_path.open("a+b")
+        try:
+            _acquire_lock(lock_file)
+        except OSError as exc:
+            lock_file.close()
+            if exc.errno in (errno.EACCES, errno.EAGAIN):
+                raise CheckpointInUseError(
+                    f"Checkpoint directory {self._checkpoint_dir} is already "
+                    "owned by another process."
+                ) from exc
+            raise CheckpointError(
+                f"Could not lock checkpoint directory {self._checkpoint_dir}: "
+                f"{exc}"
+            ) from exc
+        self._lock_file = lock_file
+        return self
+
+    def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            traceback: TracebackType | None,
+    ) -> None:
+        del exc_type, exc_value, traceback
+        lock_file = self._lock_file
+        if lock_file is None:
+            return
+        _release_lock(lock_file)
+        lock_file.close()
+        self._lock_file = None
+
+    def load(self) -> StateType | None:
+        """Load the latest committed generation after checksum verification."""
+        self._require_lock()
+        manifest_path = self._checkpoint_dir / MANIFEST_NAME
+        if not manifest_path.exists():
+            incomplete = tuple(self._checkpoint_dir.glob(f"{STATE_PREFIX}*"))
+            incomplete += tuple(self._checkpoint_dir.glob(".*.tmp.pkl"))
+            if incomplete:
+                raise CheckpointCorruptionError(
+                    "Checkpoint state files exist without a committed "
+                    "CHECKPOINT manifest. Restore or clear the incomplete "
+                    "checkpoint directory."
+                )
+            return None
+
+        try:
+            manifest_data = manifest_path.read_bytes()
+        except OSError as exc:
+            raise CheckpointCorruptionError(
+                f"Could not read checkpoint manifest {manifest_path}."
+            ) from exc
+        manifest = CheckpointManifest.from_json_bytes(manifest_data)
+        state_path = self._checkpoint_dir / manifest.state_file
+        if not state_path.is_file():
+            raise CheckpointCorruptionError(
+                f"Checkpoint state file {manifest.state_file} is missing."
+            )
+        checksum = _sha256(state_path)
+        if checksum != manifest.checksum:
+            raise CheckpointCorruptionError(
+                f"Checkpoint checksum mismatch for {manifest.state_file}. "
+                "The state was not deserialized."
+            )
+        try:
+            state = cast(StateType, Pytree.load(str(state_path)))
+        except Exception as exc:
+            raise CheckpointCorruptionError(
+                f"Checkpoint {manifest.state_file} passed its checksum but "
+                "could not be deserialized in this Python environment."
+            ) from exc
+        self._manifest = manifest
+        self._saved_state = state
+        self._last_checkpoint_time = self._clock()
+        jaxns_logger.info(
+            "Loaded checkpoint generation %d from %s.",
+            manifest.generation,
+            self._checkpoint_dir,
+        )
+        return state
+
+    def maybe_save(self, state: StateType) -> bool:
+        """Persist ``state`` when the configured monotonic cadence is due."""
+        now = self._clock()
+        if now - self._last_checkpoint_time < self._cadence_seconds:
+            return False
+        self.save(state, checkpoint_time=now)
+        return True
+
+    def save_if_changed(self, state: StateType) -> bool:
+        """Persist a final or exceptional state unless it was just saved."""
+        if state is self._saved_state:
+            return False
+        self.save(state)
+        return True
+
+    def save(
+            self,
+            state: StateType,
+            checkpoint_time: float | None = None,
+    ) -> None:
+        """Durably publish the complete Pytree as one new generation."""
+        self._require_lock()
+        generation = 1
+        if self._manifest is not None:
+            generation = self._manifest.generation + 1
+        state_name = _state_name(generation)
+        state_path = self._checkpoint_dir / state_name
+        state_temporary = self._checkpoint_dir / (
+            f".{state_name}.{uuid4().hex}.tmp.pkl"
+        )
+        try:
+            # Pytree.save is the single serialization surface. Durability and
+            # publication remain filesystem concerns owned by this manager.
+            state.save(str(state_temporary))
+            _fsync_file(state_temporary)
+            checksum = _sha256(state_temporary)
+            os.replace(state_temporary, state_path)
+            _fsync_directory(self._checkpoint_dir)
+        except Exception:
+            state_temporary.unlink(missing_ok=True)
+            raise
+
+        manifest = CheckpointManifest(
+            schema_version=CHECKPOINT_SCHEMA_VERSION,
+            generation=generation,
+            state_file=state_name,
+            checksum_algorithm=CHECKSUM_ALGORITHM,
+            checksum=checksum,
+        )
+        manifest_temporary = self._checkpoint_dir / (
+            f".{MANIFEST_NAME}.{uuid4().hex}.tmp"
+        )
+        try:
+            with manifest_temporary.open("wb") as file:
+                file.write(manifest.to_json_bytes())
+                file.flush()
+                os.fsync(file.fileno())
+            # The manifest is the commit record. Publishing it last ensures a
+            # reader sees either the prior complete generation or this one.
+            os.replace(
+                manifest_temporary,
+                self._checkpoint_dir / MANIFEST_NAME,
+            )
+            _fsync_directory(self._checkpoint_dir)
+        except Exception:
+            manifest_temporary.unlink(missing_ok=True)
+            raise
+
+        self._manifest = manifest
+        self._saved_state = state
+        if checkpoint_time is None:
+            checkpoint_time = self._clock()
+        self._last_checkpoint_time = checkpoint_time
+        try:
+            self._prune_old_generations()
+        except OSError as exc:
+            # Publication is already durable. A cleanup failure may consume
+            # extra disk space, but reporting the committed save as failed
+            # would give the caller a false recovery picture.
+            jaxns_logger.warning(
+                "Checkpoint generation %d is valid, but old generations "
+                "could not be pruned from %s: %s",
+                generation,
+                self._checkpoint_dir,
+                exc,
+            )
+        jaxns_logger.info(
+            "Saved checkpoint generation %d to %s.",
+            generation,
+            self._checkpoint_dir,
+        )
+
+    def _prune_old_generations(self) -> None:
+        state_paths = sorted(
+            path
+            for path in self._checkpoint_dir.glob(
+                f"{STATE_PREFIX}*{STATE_SUFFIX}"
+            )
+            if _is_state_name(path.name)
+        )
+        for state_path in state_paths[:-RETAINED_GENERATIONS]:
+            state_path.unlink()
+        if len(state_paths) > RETAINED_GENERATIONS:
+            _fsync_directory(self._checkpoint_dir)
+
+    def _require_lock(self) -> None:
+        if self._lock_file is None:
+            raise RuntimeError(
+                "CheckpointManager must be entered before loading or saving."
+            )
+
+
+def _state_name(generation: int) -> str:
+    return f"{STATE_PREFIX}{generation:020d}{STATE_SUFFIX}"
+
+
+def _is_state_name(name: str) -> bool:
+    if not name.startswith(STATE_PREFIX) or not name.endswith(STATE_SUFFIX):
+        return False
+    generation = name[len(STATE_PREFIX):-len(STATE_SUFFIX)]
+    return len(generation) == 20 and generation.isdecimal()
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        while True:
+            chunk = file.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _fsync_file(path: Path) -> None:
+    with path.open("rb+") as file:
+        os.fsync(file.fileno())
+
+
+if os.name == "nt":
+    import msvcrt
+
+    def _acquire_lock(file) -> None:
+        file.seek(0)
+        if file.read(1) == b"":
+            file.write(b"\0")
+            file.flush()
+        file.seek(0)
+        msvcrt.locking(file.fileno(), msvcrt.LK_NBLCK, 1)
+
+    def _release_lock(file) -> None:
+        file.seek(0)
+        msvcrt.locking(file.fileno(), msvcrt.LK_UNLCK, 1)
+
+    def _fsync_directory(path: Path) -> None:
+        # Windows has no directory file descriptor compatible with fsync.
+        # os.replace still provides atomic publication on one volume.
+        del path
+
+else:
+    import fcntl
+
+    def _acquire_lock(file) -> None:
+        fcntl.flock(file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def _release_lock(file) -> None:
+        fcntl.flock(file.fileno(), fcntl.LOCK_UN)
+
+    def _fsync_directory(path: Path) -> None:
+        descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)

--- a/src/jaxns/core.py
+++ b/src/jaxns/core.py
@@ -3,6 +3,7 @@
 import dataclasses
 from collections.abc import Callable
 from functools import partial
+from pathlib import Path
 from typing import Any, Literal, NamedTuple
 
 import jax
@@ -10,6 +11,10 @@ import jax.numpy as jnp
 from jaxctx import CtxParams
 
 from jaxns.allocation import AllocationPlan, build_allocation_plan
+from jaxns.checkpoint import (
+    CHECKPOINT_CADENCE_SECONDS,
+    CheckpointManager,
+)
 from jaxns.constrained_sampler import (
     AbstractSampler,
     ConstrainedSampleBatch,
@@ -1292,8 +1297,24 @@ class NestedSampler(PureDataclassPytree):
             depth_reached=jnp.asarray(True, mp_policy.bool_dtype),
         )
 
-    def run(self, key: PRNGKey | None = None) -> State:
-        """Run until the default expectation-based goal is satisfied."""
+    def run(
+            self,
+            key: PRNGKey | None = None,
+            checkpoint_dir: str | Path | None = None,
+            checkpoint_cadence: float = CHECKPOINT_CADENCE_SECONDS,
+    ) -> State:
+        """Run until the default expectation-based goal is satisfied.
+
+        Args:
+            key: Random key used only when starting a new run.
+            checkpoint_dir: Optional directory for automatic full-state
+                checkpointing and resume.
+            checkpoint_cadence: Minimum seconds between depth-boundary
+                checkpoints. The final state is always saved when changed.
+
+        Returns:
+            The completed or terminal immutable state.
+        """
         if key is None:
             key = jax.random.PRNGKey(42)
 
@@ -1305,21 +1326,64 @@ class NestedSampler(PureDataclassPytree):
             )
             return bool(done)
 
-        return self.run_until_goal(default_goal, key=key)
+        return self.run_until_goal(
+            default_goal,
+            key=key,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_cadence=checkpoint_cadence,
+        )
 
     def run_until_goal(
             self,
             goal_cond: Callable[[State], bool],
             depth_cond: TerminationCondition | None = None,
             key: PRNGKey | None = None,
+            checkpoint_dir: str | Path | None = None,
+            checkpoint_cadence: float = CHECKPOINT_CADENCE_SECONDS,
     ) -> State:
-        """Run a Python goal loop around compiled JAX depth epochs."""
+        """Run a Python goal loop around compiled JAX depth epochs.
+
+        A valid checkpoint in ``checkpoint_dir`` takes precedence over
+        ``key`` and resumes its stored random stream. JAXNS verifies the
+        checkpoint schema and checksum; the caller is responsible for using a
+        compatible model, sampler, arguments, and run configuration.
+
+        Args:
+            goal_cond: Python goal evaluated at complete depth boundaries.
+            depth_cond: Optional condition bounding one allocation epoch.
+            key: Random key used only when no checkpoint exists.
+            checkpoint_dir: Optional directory for automatic full-state
+                checkpointing and resume.
+            checkpoint_cadence: Minimum seconds between depth-boundary
+                checkpoints. The default is one hour.
+
+        Returns:
+            The completed or terminal immutable state.
+        """
+        if checkpoint_dir is not None:
+            with CheckpointManager[State](
+                checkpoint_dir,
+                checkpoint_cadence,
+            ) as checkpoint_manager:
+                state = checkpoint_manager.load()
+                if state is None:
+                    state = self.initialise(key)
+                state = self._resume_until_goal(
+                    state,
+                    goal_cond,
+                    depth_cond=depth_cond,
+                    key=None,
+                    checkpoint_manager=checkpoint_manager,
+                )
+                checkpoint_manager.save_if_changed(state)
+                return state
         state = self.initialise(key)
         return self._resume_until_goal(
             state,
             goal_cond,
             depth_cond=depth_cond,
             key=None,
+            checkpoint_manager=None,
         )
 
     def resume_until_goal(
@@ -1328,13 +1392,52 @@ class NestedSampler(PureDataclassPytree):
             goal_cond: Callable[[State], bool],
             depth_cond: TerminationCondition | None = None,
             key: PRNGKey | None = None,
+            checkpoint_dir: str | Path | None = None,
+            checkpoint_cadence: float = CHECKPOINT_CADENCE_SECONDS,
     ) -> State:
-        """Resume an immutable state under a user-provided Python goal."""
+        """Resume an immutable state under a user-provided Python goal.
+
+        If ``checkpoint_dir`` already contains a valid checkpoint, its state
+        takes precedence over the explicit ``state`` and ``key``.
+
+        Args:
+            state: Explicit state used when no checkpoint exists.
+            goal_cond: Python goal evaluated at complete depth boundaries.
+            depth_cond: Optional condition bounding one allocation epoch.
+            key: Optional replacement continuation key when no checkpoint
+                exists.
+            checkpoint_dir: Optional directory for automatic full-state
+                checkpointing and resume.
+            checkpoint_cadence: Minimum seconds between depth-boundary
+                checkpoints. The default is one hour.
+
+        Returns:
+            The completed or terminal immutable state.
+        """
+        if checkpoint_dir is not None:
+            with CheckpointManager[State](
+                checkpoint_dir,
+                checkpoint_cadence,
+            ) as checkpoint_manager:
+                restored = checkpoint_manager.load()
+                if restored is not None:
+                    state = restored
+                    key = None
+                state = self._resume_until_goal(
+                    state,
+                    goal_cond,
+                    depth_cond=depth_cond,
+                    key=key,
+                    checkpoint_manager=checkpoint_manager,
+                )
+                checkpoint_manager.save_if_changed(state)
+                return state
         return self._resume_until_goal(
             state,
             goal_cond,
             depth_cond=depth_cond,
             key=key,
+            checkpoint_manager=None,
         )
 
     def _resume_until_goal(
@@ -1344,6 +1447,7 @@ class NestedSampler(PureDataclassPytree):
             *,
             depth_cond: TerminationCondition | None,
             key: PRNGKey | None,
+            checkpoint_manager: CheckpointManager[State] | None,
     ) -> State:
         if depth_cond is None:
             depth_cond = self.termination_condition
@@ -1433,6 +1537,11 @@ class NestedSampler(PureDataclassPytree):
                         + jnp.asarray(1, state.goal_loop_iter.dtype)
                     ),
                 )
+                # Checkpoint only after the logical depth is complete. A
+                # capacity return is a physical interruption of the same
+                # epoch and must not become a persisted goal boundary.
+                if checkpoint_manager is not None:
+                    checkpoint_manager.maybe_save(state)
                 continue
             raise RuntimeError(
                 "Compiled depth returned without termination, growth, or "
@@ -1457,8 +1566,58 @@ class NestedSampler(PureDataclassPytree):
             state: State | None = None,
             depth_cond: TerminationCondition | None = None,
             key: PRNGKey | None = None,
+            checkpoint_dir: str | Path | None = None,
+            checkpoint_cadence: float = CHECKPOINT_CADENCE_SECONDS,
     ) -> State:
-        """Run exactly one compiled depth epoch."""
+        """Run exactly one compiled depth epoch.
+
+        When checkpointing is enabled, an existing committed state takes
+        precedence over ``state`` and the returned state is persisted. The
+        cadence does not defer that final save because this method has only
+        one Python depth boundary.
+
+        Args:
+            state: Optional explicit continuation state.
+            depth_cond: Optional condition bounding the allocation epoch.
+            key: Random key used only when starting or explicitly overriding
+                a state without a checkpoint.
+            checkpoint_dir: Optional directory for automatic full-state
+                checkpointing and resume.
+            checkpoint_cadence: Checkpoint cadence in seconds, retained for a
+                consistent run API.
+
+        Returns:
+            The immutable state returned by one compiled depth epoch.
+        """
+        if checkpoint_dir is not None:
+            with CheckpointManager[State](
+                checkpoint_dir,
+                checkpoint_cadence,
+            ) as checkpoint_manager:
+                restored = checkpoint_manager.load()
+                if restored is not None:
+                    state = restored
+                    key = None
+                state = self._run_single_iteration(
+                    state=state,
+                    depth_cond=depth_cond,
+                    key=key,
+                )
+                checkpoint_manager.save_if_changed(state)
+                return state
+        return self._run_single_iteration(
+            state=state,
+            depth_cond=depth_cond,
+            key=key,
+        )
+
+    def _run_single_iteration(
+            self,
+            state: State | None,
+            depth_cond: TerminationCondition | None,
+            key: PRNGKey | None,
+    ) -> State:
+        """Execute one depth epoch after checkpoint ownership is resolved."""
         if state is None:
             state = self.initialise(key)
         elif key is not None:

--- a/src/jaxns/core.py
+++ b/src/jaxns/core.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 from collections.abc import Callable
+from contextlib import nullcontext
 from functools import partial
 from pathlib import Path
 from typing import Any, Literal, NamedTuple
@@ -1360,30 +1361,13 @@ class NestedSampler(PureDataclassPytree):
         Returns:
             The completed or terminal immutable state.
         """
-        if checkpoint_dir is not None:
-            with CheckpointManager[State](
-                checkpoint_dir,
-                checkpoint_cadence,
-            ) as checkpoint_manager:
-                state = checkpoint_manager.load()
-                if state is None:
-                    state = self.initialise(key)
-                state = self._resume_until_goal(
-                    state,
-                    goal_cond,
-                    depth_cond=depth_cond,
-                    key=None,
-                    checkpoint_manager=checkpoint_manager,
-                )
-                checkpoint_manager.save_if_changed(state)
-                return state
-        state = self.initialise(key)
         return self._resume_until_goal(
-            state,
+            None,
             goal_cond,
             depth_cond=depth_cond,
-            key=None,
-            checkpoint_manager=None,
+            key=key,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_cadence=checkpoint_cadence,
         )
 
     def resume_until_goal(
@@ -1414,33 +1398,55 @@ class NestedSampler(PureDataclassPytree):
         Returns:
             The completed or terminal immutable state.
         """
-        if checkpoint_dir is not None:
-            with CheckpointManager[State](
-                checkpoint_dir,
-                checkpoint_cadence,
-            ) as checkpoint_manager:
-                restored = checkpoint_manager.load()
-                if restored is not None:
-                    state = restored
-                    key = None
-                state = self._resume_until_goal(
-                    state,
-                    goal_cond,
-                    depth_cond=depth_cond,
-                    key=key,
-                    checkpoint_manager=checkpoint_manager,
-                )
-                checkpoint_manager.save_if_changed(state)
-                return state
         return self._resume_until_goal(
             state,
             goal_cond,
             depth_cond=depth_cond,
             key=key,
-            checkpoint_manager=None,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_cadence=checkpoint_cadence,
         )
 
     def _resume_until_goal(
+            self,
+            state: State | None,
+            goal_cond: Callable[[State], bool],
+            *,
+            depth_cond: TerminationCondition | None,
+            key: PRNGKey | None,
+            checkpoint_dir: str | Path | None,
+            checkpoint_cadence: float,
+    ) -> State:
+        """Resolve checkpoint precedence, then continue one goal loop."""
+        checkpoint_context = (
+            CheckpointManager[State](
+                checkpoint_dir,
+                checkpoint_cadence,
+            )
+            if checkpoint_dir is not None
+            else nullcontext()
+        )
+        with checkpoint_context as checkpoint_manager:
+            if checkpoint_manager is not None:
+                restored = checkpoint_manager.load()
+                if restored is not None:
+                    state = restored
+                    key = None
+            if state is None:
+                state = self.initialise(key)
+                key = None
+            completed = self._run_goal_loop(
+                state,
+                goal_cond,
+                depth_cond=depth_cond,
+                key=key,
+                checkpoint_manager=checkpoint_manager,
+            )
+            if checkpoint_manager is not None:
+                checkpoint_manager.save_if_changed(completed)
+            return completed
+
+    def _run_goal_loop(
             self,
             state: State,
             goal_cond: Callable[[State], bool],
@@ -1449,6 +1455,7 @@ class NestedSampler(PureDataclassPytree):
             key: PRNGKey | None,
             checkpoint_manager: CheckpointManager[State] | None,
     ) -> State:
+        """Continue compiled depths after checkpoint ownership is resolved."""
         if depth_cond is None:
             depth_cond = self.termination_condition
         if key is not None:

--- a/src/jaxns/distributed_core.py
+++ b/src/jaxns/distributed_core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses
 import time
 from collections.abc import Callable
+from contextlib import nullcontext
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NamedTuple
@@ -918,33 +919,13 @@ class DistributedNestedSampler:
             A drained distributed checkpoint suitable for results or
             resumption.
         """
-        if checkpoint_dir is not None:
-            with CheckpointManager[DistributedState](
-                checkpoint_dir,
-                checkpoint_cadence,
-            ) as checkpoint_manager:
-                distributed = checkpoint_manager.load()
-                if distributed is None:
-                    completed = self._run_until_goal(
-                        goal_cond,
-                        depth_cond=depth_cond,
-                        key=key,
-                        checkpoint_manager=checkpoint_manager,
-                    )
-                else:
-                    completed = self._resume_until_goal(
-                        distributed,
-                        goal_cond,
-                        depth_cond=depth_cond,
-                        checkpoint_manager=checkpoint_manager,
-                    )
-                checkpoint_manager.save_if_changed(completed)
-                return completed
-        return self._run_until_goal(
+        return self._resume_until_goal(
+            None,
             goal_cond,
             depth_cond=depth_cond,
             key=key,
-            checkpoint_manager=None,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_cadence=checkpoint_cadence,
         )
 
     def _run_until_goal(
@@ -1036,30 +1017,58 @@ class DistributedNestedSampler:
                 field contains every reservation and task created before the
                 failure and can be passed back to this method.
         """
-        if checkpoint_dir is not None:
-            with CheckpointManager[DistributedState](
+        return self._resume_until_goal(
+            distributed,
+            goal_cond,
+            depth_cond=depth_cond,
+            key=None,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_cadence=checkpoint_cadence,
+        )
+
+    def _resume_until_goal(
+            self,
+            distributed: DistributedState | None,
+            goal_cond: Callable[[State], bool],
+            *,
+            depth_cond: TerminationCondition | None,
+            key: PRNGKey | None,
+            checkpoint_dir: str | Path | None,
+            checkpoint_cadence: float,
+    ) -> DistributedState:
+        """Resolve checkpoint precedence before starting or resuming."""
+        checkpoint_context = (
+            CheckpointManager[DistributedState](
                 checkpoint_dir,
                 checkpoint_cadence,
-            ) as checkpoint_manager:
+            )
+            if checkpoint_dir is not None
+            else nullcontext()
+        )
+        with checkpoint_context as checkpoint_manager:
+            if checkpoint_manager is not None:
                 restored = checkpoint_manager.load()
                 if restored is not None:
                     distributed = restored
-                completed = self._resume_until_goal(
+            if distributed is None:
+                completed = self._run_until_goal(
+                    goal_cond,
+                    depth_cond=depth_cond,
+                    key=key,
+                    checkpoint_manager=checkpoint_manager,
+                )
+            else:
+                completed = self._resume_distributed_goal_loop(
                     distributed,
                     goal_cond,
                     depth_cond=depth_cond,
                     checkpoint_manager=checkpoint_manager,
                 )
+            if checkpoint_manager is not None:
                 checkpoint_manager.save_if_changed(completed)
-                return completed
-        return self._resume_until_goal(
-            distributed,
-            goal_cond,
-            depth_cond=depth_cond,
-            checkpoint_manager=None,
-        )
+            return completed
 
-    def _resume_until_goal(
+    def _resume_distributed_goal_loop(
             self,
             distributed: DistributedState,
             goal_cond: Callable[[State], bool],

--- a/src/jaxns/distributed_core.py
+++ b/src/jaxns/distributed_core.py
@@ -6,6 +6,7 @@ import dataclasses
 import time
 from collections.abc import Callable
 from functools import partial
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NamedTuple
 from uuid import uuid4
 
@@ -14,6 +15,10 @@ import jax.numpy as jnp
 import numpy as np
 from jaxctx import CtxParams
 
+from jaxns.checkpoint import (
+    CHECKPOINT_CADENCE_SECONDS,
+    CheckpointManager,
+)
 from jaxns.constrained_sampler import (
     AbstractSampler,
     ConstrainedSampleBatch,
@@ -851,8 +856,24 @@ class DistributedNestedSampler:
                 waiting_logged = True
             time.sleep(min(1.0, max(0.1, self.receive_timeout_s)))
 
-    def run(self, key: PRNGKey | None = None) -> DistributedState:
-        """Run until the configured expectation-based goal is met."""
+    def run(
+            self,
+            key: PRNGKey | None = None,
+            checkpoint_dir: str | Path | None = None,
+            checkpoint_cadence: float = CHECKPOINT_CADENCE_SECONDS,
+    ) -> DistributedState:
+        """Run until the configured expectation-based goal is met.
+
+        Args:
+            key: Random key used only when starting a new run.
+            checkpoint_dir: Optional directory for automatic full-state
+                checkpointing and resume.
+            checkpoint_cadence: Minimum seconds between drained depth-boundary
+                checkpoints. The final state is always saved when changed.
+
+        Returns:
+            A drained distributed state suitable for results or resumption.
+        """
 
         def default_goal(state: State) -> bool:
             if int(state.goal_loop_iter) == 0:
@@ -862,24 +883,79 @@ class DistributedNestedSampler:
             )
             return bool(done)
 
-        return self.run_until_goal(default_goal, key=key)
+        return self.run_until_goal(
+            default_goal,
+            key=key,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_cadence=checkpoint_cadence,
+        )
 
     def run_until_goal(
             self,
             goal_cond: Callable[[State], bool],
             depth_cond: TerminationCondition | None = None,
             key: PRNGKey | None = None,
+            checkpoint_dir: str | Path | None = None,
+            checkpoint_cadence: float = CHECKPOINT_CADENCE_SECONDS,
     ) -> DistributedState:
         """Initialise and run the asynchronous Python goal/depth loops.
+
+        A valid checkpoint in ``checkpoint_dir`` takes precedence over
+        ``key`` and resumes its stored random stream and pending work. JAXNS
+        verifies storage integrity, while compatible model, sampler, and run
+        configuration remain the caller's responsibility.
 
         Args:
             goal_cond: User goal evaluated only on drained immutable states.
             depth_cond: Expectation-based boundary for each allocation epoch.
             key: Run random key; a deterministic default is used when absent.
+            checkpoint_dir: Optional directory for automatic full-state
+                checkpointing and resume.
+            checkpoint_cadence: Minimum seconds between drained depth-boundary
+                checkpoints. The default is one hour.
 
         Returns:
-            A drained distributed checkpoint suitable for results or resumption.
+            A drained distributed checkpoint suitable for results or
+            resumption.
         """
+        if checkpoint_dir is not None:
+            with CheckpointManager[DistributedState](
+                checkpoint_dir,
+                checkpoint_cadence,
+            ) as checkpoint_manager:
+                distributed = checkpoint_manager.load()
+                if distributed is None:
+                    completed = self._run_until_goal(
+                        goal_cond,
+                        depth_cond=depth_cond,
+                        key=key,
+                        checkpoint_manager=checkpoint_manager,
+                    )
+                else:
+                    completed = self._resume_until_goal(
+                        distributed,
+                        goal_cond,
+                        depth_cond=depth_cond,
+                        checkpoint_manager=checkpoint_manager,
+                    )
+                checkpoint_manager.save_if_changed(completed)
+                return completed
+        return self._run_until_goal(
+            goal_cond,
+            depth_cond=depth_cond,
+            key=key,
+            checkpoint_manager=None,
+        )
+
+    def _run_until_goal(
+            self,
+            goal_cond: Callable[[State], bool],
+            *,
+            depth_cond: TerminationCondition | None,
+            key: PRNGKey | None,
+            checkpoint_manager: CheckpointManager[DistributedState] | None,
+    ) -> DistributedState:
+        """Start a new distributed session after checkpoint resolution."""
         from jaxns.runtime_client import SupervisorClient
 
         if depth_cond is None:
@@ -908,35 +984,90 @@ class DistributedNestedSampler:
                     distributed,
                     goal_cond,
                     depth_cond,
+                    checkpoint_manager,
                 )
                 distributed = completed
                 client.release(session_id)
                 return completed
-            except DistributedRunError:
+            except DistributedRunError as exc:
+                if checkpoint_manager is not None:
+                    checkpoint_manager.save_if_changed(exc.checkpoint)
                 raise
             except Exception as exc:
                 if distributed is None:
                     raise RuntimeError(
                         f"Distributed initialization failed: {exc}"
                     ) from exc
-                raise DistributedRunError(
+                error = DistributedRunError(
                     f"Distributed execution failed: {exc}",
                     distributed,
-                ) from exc
+                )
+                if checkpoint_manager is not None:
+                    checkpoint_manager.save_if_changed(distributed)
+                raise error from exc
 
     def resume_until_goal(
             self,
             distributed: DistributedState,
             goal_cond: Callable[[State], bool],
             depth_cond: TerminationCondition | None = None,
+            checkpoint_dir: str | Path | None = None,
+            checkpoint_cadence: float = CHECKPOINT_CADENCE_SECONDS,
     ) -> DistributedState:
         """Resume an immutable checkpoint, including retry-stable tasks.
+
+        If ``checkpoint_dir`` already contains a valid checkpoint, its state
+        takes precedence over the explicit ``distributed`` state.
+
+        Args:
+            distributed: Explicit state used when no checkpoint exists.
+            goal_cond: User goal evaluated only on drained immutable states.
+            depth_cond: Expectation-based boundary for each allocation epoch.
+            checkpoint_dir: Optional directory for automatic full-state
+                checkpointing and resume.
+            checkpoint_cadence: Minimum seconds between drained depth-boundary
+                checkpoints. The default is one hour.
+
+        Returns:
+            A drained distributed state suitable for results or resumption.
 
         Raises:
             DistributedRunError: If runtime work fails. Its ``checkpoint``
                 field contains every reservation and task created before the
                 failure and can be passed back to this method.
         """
+        if checkpoint_dir is not None:
+            with CheckpointManager[DistributedState](
+                checkpoint_dir,
+                checkpoint_cadence,
+            ) as checkpoint_manager:
+                restored = checkpoint_manager.load()
+                if restored is not None:
+                    distributed = restored
+                completed = self._resume_until_goal(
+                    distributed,
+                    goal_cond,
+                    depth_cond=depth_cond,
+                    checkpoint_manager=checkpoint_manager,
+                )
+                checkpoint_manager.save_if_changed(completed)
+                return completed
+        return self._resume_until_goal(
+            distributed,
+            goal_cond,
+            depth_cond=depth_cond,
+            checkpoint_manager=None,
+        )
+
+    def _resume_until_goal(
+            self,
+            distributed: DistributedState,
+            goal_cond: Callable[[State], bool],
+            *,
+            depth_cond: TerminationCondition | None,
+            checkpoint_manager: CheckpointManager[DistributedState] | None,
+    ) -> DistributedState:
+        """Reconnect one resolved immutable distributed state."""
         from jaxns.runtime_client import SupervisorClient
 
         if depth_cond is None:
@@ -965,17 +1096,23 @@ class DistributedNestedSampler:
                     distributed,
                     goal_cond,
                     depth_cond,
+                    checkpoint_manager,
                 )
                 distributed = completed
                 client.release(completed.session_id)
                 return completed
-            except DistributedRunError:
+            except DistributedRunError as exc:
+                if checkpoint_manager is not None:
+                    checkpoint_manager.save_if_changed(exc.checkpoint)
                 raise
             except Exception as exc:
-                raise DistributedRunError(
+                error = DistributedRunError(
                     f"Distributed execution failed: {exc}",
                     distributed,
-                ) from exc
+                )
+                if checkpoint_manager is not None:
+                    checkpoint_manager.save_if_changed(distributed)
+                raise error from exc
 
     def _run_connected(
             self,
@@ -983,6 +1120,7 @@ class DistributedNestedSampler:
             distributed: DistributedState,
             goal_cond: Callable[[State], bool],
             depth_cond: TerminationCondition,
+            checkpoint_manager: CheckpointManager[DistributedState] | None,
     ) -> DistributedState:
         completed_tasks: dict[
             int,
@@ -1146,6 +1284,11 @@ class DistributedNestedSampler:
                     state=state,
                     depth_active=False,
                 )
+                # At this point every task from the depth is committed and no
+                # provisional reservation is present. The checkpoint therefore
+                # exposes exactly the same immutable state seen by goal_cond.
+                if checkpoint_manager is not None:
+                    checkpoint_manager.maybe_save(distributed)
                 continue
             if bool(status.has_work):
                 # A pool may temporarily have no live lanes while an operator


### PR DESCRIPTION
Closes #270.

## Outcome

Adds opt-in automatic checkpointing and automatic resume to the local and distributed scientific run APIs. A run with no `checkpoint_dir` follows the ordinary path without filesystem work. When a directory is supplied, JAXNS restores the latest committed complete `State` or `DistributedState`, including its random stream and retry-stable pending distributed work.

## Architecture and intent

- Uses the existing `Pytree.save`/`Pytree.load` serialization surface for the entire immutable state; the checkpoint layer does not duplicate or selectively reconstruct scientific state.
- Checks cadence only at coherent Python depth boundaries. Local capacity growth is an interruption of the same logical depth and is not checkpointed as a goal boundary. Distributed cadence checkpoints occur only after all work from the depth has been committed.
- Saves a changed final state regardless of cadence. Retryable distributed failures save the complete pending state before surfacing the error.
- Writes each generation to a same-directory temporary file, fsyncs it, computes SHA-256, atomically publishes the state, then atomically publishes a strict `CHECKPOINT` manifest as the commit record.
- Verifies manifest schema and checksum before pickle deserialization. Missing, malformed, incomplete, unsupported, and corrupt commits fail closed; there is no silent scientific rollback.
- Retains two generations for explicit operator recovery and holds one process lock for the full run to prevent competing continuations.
- Deliberately does not fingerprint or infer model, arguments, sampler, or runner compatibility. As agreed in #270, the caller owns that contract.

Alternatives rejected:

- Selective/derived checkpoint payloads: duplicate the state schema and risk omitting continuation data. The complete immutable Pytree is the authoritative recovery unit.
- A sidecar checksum without atomic manifest publication: cannot distinguish an interrupted update from a committed generation.
- Silent fallback to an older generation: can conceal corruption and resume scientifically stale work.
- Checkpointing local capacity-growth returns: would expose a physical allocation boundary as a logical depth boundary.

## Performance evidence

The committed benchmark compares this branch with `develop` at `7c34ca7`, using Python 3.12.9, JAX/JAXLIB 0.10.0, x64, and one CPU device.

| Measurement | `develop` | This branch | Branch / develop |
|---|---:|---:|---:|
| Compile + first run | 1.74044 s | 1.74059 s | 1.00009 |
| Steady median, 200 runs | 3.335 ms | 3.275 ms | 0.9820 |
| Steady mean, 200 runs | 3.335 ms | 3.309 ms | 0.9923 |
| Scientific signatures | exact | exact | — |

The disabled path has no measured regression and does not alter the compiled JAX depth program.

For the enabled path, a complete 8D `State` with physical capacity 1,000,000 occupied 104,001,927 bytes. Five full durable saves took 0.5717–0.6172 s, median 0.6014 s. At the default one-hour cadence, that is 0.0167% amortized wall time on the measured local filesystem. This is not presented as an NFS or parallel-filesystem throughput claim; cadence remains configurable.

Reproduction and raw summary: `benchmarks/issue_270/`.

## Correctness evidence

- Exact local interrupted/resumed state equals uninterrupted continuation, including random stream.
- A real supervisor/worker distributed run checkpoints after one goal epoch and resumes the same directory to the next goal with a deliberately unrelated supplied key.
- Complete distributed pending task identities, requests, reservations, and keys survive serialization.
- Corrupt bytes are rejected before deserialization.
- Injected interruptions during state write and manifest publication preserve the prior commit.
- Malformed manifests, missing state, unsupported schemas, and incomplete directories fail clearly.
- A spawned competing process cannot acquire the directory while a run owns it.
- Cadence uses a monotonic clock and retains exactly two generations.

## Validation

- Full repository unit suite: 278 passed
- GitHub required matrix, Python 3.10 through 3.14: passed
- `cicd/tests/test_checkpoint.py` + reviewer autochecks: 19 passed
- Real distributed supervisor/worker checkpoint-resume test: passed
- Local run round-trip system test: passed
- Focused core/distributed/reviewer suite: 50 passed
- `ruff`: passed
- `flake8` on new checkpoint/test/benchmark modules: passed
- `git diff --check`: passed
