### PR TITLE
Decouple retained phantoms from MC conditioning prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ sampler = NestedSampler(
     model=model,
     args=args,
     collect_phantom_samples=True,
+    max_phantom_samples=2,
 )
 state = sampler.run(key=jax.random.PRNGKey(6))
 results = state.to_result().trim()
@@ -156,7 +157,25 @@ results.plot_evidence(
     key=jax.random.PRNGKey(3),
     exact_log_Z=-0.274366,
 )
+
+# Reuse the same retained clusters with a shorter conditioning prefix.
+prefix_evidence = results.sample_evidence_mc(
+    num_samples=4096,
+    conditioning="phantom",
+    num_phantoms=1,
+    key=jax.random.PRNGKey(4),
+)
 ```
+
+Phantom collection and evidence conditioning are separate choices. The
+sampler retains the first `max_phantom_samples` eligible transitions from each
+chain and always reserves the final transition for the classic replacement.
+Omitting the bound keeps one model dimension of phantom states by default.
+At evidence time, `num_phantoms=None` uses every retained state; an explicit
+value uses that many states from the same start prefix without rerunning nested
+sampling. Retaining more states increases result/checkpoint memory, while a
+shorter evidence prefix is physically sliced before JAX compilation so its
+unused suffix adds no MC-kernel work.
 
 A fixed-seed CPU run of the example above produces this summary:
 

--- a/benchmarks/gh123/main.py
+++ b/benchmarks/gh123/main.py
@@ -55,7 +55,7 @@ def build_run_model(k):
             model=model,
             num_slices=num_slices,
             collect_phantom_samples=(k > 0),
-            phantom_burn_in=(num_slices - 1 - k) if k > 0 else None
+            max_phantom_samples=k if k > 0 else None,
         )
         ns = NestedSampler(model=model, sampler=sampler)
 

--- a/benchmarks/issue_244/run_paired.py
+++ b/benchmarks/issue_244/run_paired.py
@@ -67,7 +67,6 @@ def main() -> int:
         dimension = int(model.U_ndims())
         num_slices = 5 * dimension
         phantom_count = dimension if phantoms else 0
-        burn_in = num_slices - 1 - phantom_count
         candidate = NestedSampler(
             model=model,
             collect_phantom_samples=phantoms,
@@ -79,7 +78,7 @@ def main() -> int:
                 model=model,
                 num_slices=num_slices,
                 collect_phantom_samples=phantoms,
-                phantom_burn_in=max(0, burn_in),
+                max_phantom_samples=(phantom_count if phantoms else None),
             ),
         )
         for seed in range(args.seeds):

--- a/benchmarks/issue_246/run_standard.py
+++ b/benchmarks/issue_246/run_standard.py
@@ -238,7 +238,9 @@ def main() -> None:
         model=model,
         num_slices=num_slices,
         collect_phantom_samples=args.phantoms,
-        phantom_burn_in=num_slices - 1 - retained_phantoms,
+        max_phantom_samples=(
+            retained_phantoms if args.phantoms else None
+        ),
         direction=direction,
     )
     nested_sampler = NestedSampler(

--- a/benchmarks/issue_247/check_chain_stationarity.py
+++ b/benchmarks/issue_247/check_chain_stationarity.py
@@ -63,7 +63,7 @@ def main():
         num_slices=5 * ndims,
         no_step_out=True,
         collect_phantom_samples=True,
-        phantom_burn_in=4 * ndims - 1,
+        max_phantom_samples=ndims,
     )
 
     def sample_one(sample_key, u0, log_l0):

--- a/benchmarks/issue_247/generate_diagnostics.py
+++ b/benchmarks/issue_247/generate_diagnostics.py
@@ -36,7 +36,7 @@ def _run_case(case_name: str, seed: int):
         no_step_out=True,
         gradient_guided=False,
         collect_phantom_samples=True,
-        phantom_burn_in=num_slices - 1 - ndims,
+        max_phantom_samples=ndims,
     )
     nested_sampler = NestedSampler(
         model=model,

--- a/benchmarks/issue_247/run_current_standard.py
+++ b/benchmarks/issue_247/run_current_standard.py
@@ -79,7 +79,9 @@ def main():
         no_step_out=True,
         gradient_guided=False,
         collect_phantom_samples=args.phantoms,
-        phantom_burn_in=num_slices - 1 - retained_phantoms,
+        max_phantom_samples=(
+            retained_phantoms if args.phantoms else None
+        ),
     )
     ns = NestedSampler(
         model=model,

--- a/benchmarks/issue_249/run_bounded_mc.py
+++ b/benchmarks/issue_249/run_bounded_mc.py
@@ -108,7 +108,7 @@ def main():
         no_step_out=True,
         gradient_guided=False,
         collect_phantom_samples=True,
-        phantom_burn_in=num_slices - 1 - ndims,
+        max_phantom_samples=ndims,
     )
     nested_sampler = NestedSampler(
         model=model,

--- a/benchmarks/issue_267/run_comparison.py
+++ b/benchmarks/issue_267/run_comparison.py
@@ -44,7 +44,7 @@ def sampler(model: Model, phantoms: bool) -> UniDimSliceSampler:
         model=model,
         num_slices=3,
         collect_phantom_samples=phantoms,
-        phantom_burn_in=0,
+        max_phantom_samples=2 if phantoms else None,
     )
 
 

--- a/benchmarks/issue_267/run_standard_comparison.py
+++ b/benchmarks/issue_267/run_standard_comparison.py
@@ -183,7 +183,9 @@ def main() -> int:
         model=model,
         num_slices=num_slices,
         collect_phantom_samples=args.phantoms,
-        phantom_burn_in=num_slices - 1 - retained_phantoms,
+        max_phantom_samples=(
+            retained_phantoms if args.phantoms else None
+        ),
         direction=direction,
     )
     common = {

--- a/benchmarks/issue_284/REPORT.md
+++ b/benchmarks/issue_284/REPORT.md
@@ -1,0 +1,44 @@
+# Issue 284 MC prefix benchmark
+
+## Question
+
+Does selecting a shorter phantom prefix through the public evidence API keep
+the unused retained suffix out of the compiled MC hot path?
+
+## Method
+
+`run_mc_prefix.py` completed an 8D Gaussian nested-sampling run with 512
+classic samples, 512 likelihood blocks, and eight retained phantom slots per
+cluster. It then evaluated 256 evidence draws in batches of 64 with prefixes
+of one, four, and eight. Each steady-state result is the median of seven warm
+runs. XLA's CPU memory analysis supplies the compiler-plan peak; it is the sum
+of argument, output, and temporary bytes less aliases. The benchmark also
+asserts draw-for-draw equality between public prefix selection and a physically
+sliced `log_L_phantom` result.
+
+Environment: CPU (`cpu:0`), JAX/JAXLIB 0.10.0, Python 3.12.9, x64 enabled,
+Linux 6.8.0-87-generic. Run on 2026-08-29 with:
+
+```bash
+PYTHONPATH=/tmp/jaxns-issue-284/src conda run -n jaxns_py python \
+  benchmarks/issue_284/run_mc_prefix.py \
+  --max-samples 512 --draws 256 --batch-size 64 --repeats 7 \
+  --output /tmp/issue284-final.json
+```
+
+## Results
+
+| Used prefix | Lower (s) | Compile (s) | Steady median (s) | Range (s) | Compiler peak |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 0.680 | 2.646 | 0.1333 | 0.1257–0.1501 | 10,406,152 B |
+| 4 | 0.373 | 2.323 | 0.1335 | 0.1256–0.1492 | 10,609,736 B |
+| 8 | 0.462 | 2.525 | 0.1413 | 0.1329–0.1589 | 13,591,176 B |
+
+The one-phantom executable used 23.4% less compiler-planned peak memory than
+the eight-phantom executable and had a 5.7% lower median runtime in this CPU
+run. The runtime ranges overlap, so the robust conclusion is the physical-plan
+result: the selected prefix changes the compiled phantom axis and the unused
+suffix is absent from its arguments and temporary plan. Prefix-one phantom
+arguments were 29,720 bytes versus 58,392 bytes for prefix eight. Exact output
+equality with the explicitly sliced reference confirms that this plan change
+does not alter the selected-prefix calculation.

--- a/benchmarks/issue_284/run_mc_prefix.py
+++ b/benchmarks/issue_284/run_mc_prefix.py
@@ -1,0 +1,221 @@
+"""Benchmark MC evidence prefixes on a completed eight-dimensional run."""
+
+import argparse
+import dataclasses
+import json
+import platform
+import statistics
+import time
+from pathlib import Path
+
+import jax
+import numpy as np
+from jax import numpy as jnp
+from jaxctx.priors.prior import Prior
+from tensorflow_probability.substrates import jax as tfp
+
+from jaxns.core import NestedSampler
+from jaxns.model import Model
+from jaxns.shrinkage.phantom import _sample_mc_shrinkage_summary_jit
+from jaxns.termination_condition import TerminationCondition
+
+tfpd = tfp.distributions
+
+
+def _make_model(dimension: int) -> Model:
+    def prior_model():
+        x = Prior(
+            tfpd.Uniform(
+                low=jnp.zeros((dimension,)),
+                high=jnp.ones((dimension,)),
+            ),
+            name="x",
+        ).realise()
+        return -0.5 * jnp.sum(jnp.square((x - 0.5) / 0.15))
+
+    return Model(prior_model=prior_model)
+
+
+def _compile_summary_kernel(results, prefix: int, draws: int, batch_size: int):
+    block_state = results.block_data.to_block_state()
+    kwargs = {
+        "key": jax.random.PRNGKey(284),
+        "log_L_constraints": results.log_L_constraints,
+        "log_L_classic": results.log_L,
+        "K_classic": results.num_live_points_per_sample,
+        "valid_phantom": results.valid_phantom,
+        "log_L_phantom": results.log_L_phantom[:, :prefix],
+        "num_samples": results.total_num_samples,
+        "num_Z_samples": draws,
+        "block_state": block_state,
+        "batch_size": batch_size,
+        "C_min": 20.0,
+    }
+    lower_started = time.perf_counter()
+    lowered = _sample_mc_shrinkage_summary_jit.lower(**kwargs)
+    lower_s = time.perf_counter() - lower_started
+    compile_started = time.perf_counter()
+    compiled = lowered.compile()
+    compile_s = time.perf_counter() - compile_started
+    memory = compiled.memory_analysis()
+    compiler_peak_bytes = None
+    memory_fields = None
+    if memory is not None:
+        # XLA reports these plan components separately. Aliased bytes occupy
+        # both an argument and output slot, so subtract them from the peak sum.
+        compiler_peak_bytes = (
+            memory.argument_size_in_bytes
+            + memory.output_size_in_bytes
+            + memory.temp_size_in_bytes
+            - memory.alias_size_in_bytes
+        )
+        memory_fields = {
+            "argument_bytes": memory.argument_size_in_bytes,
+            "output_bytes": memory.output_size_in_bytes,
+            "temporary_bytes": memory.temp_size_in_bytes,
+            "alias_bytes": memory.alias_size_in_bytes,
+        }
+    return {
+        "lower_s": lower_s,
+        "compile_s": compile_s,
+        "hlo_text_bytes": len(lowered.as_text().encode("utf-8")),
+        "compiler_peak_bytes": compiler_peak_bytes,
+        "memory_fields": memory_fields,
+    }
+
+
+def _measure_public_prefix(
+        results,
+        prefix: int,
+        draws: int,
+        batch_size: int,
+        repeats: int,
+) -> dict:
+    key = jax.random.PRNGKey(1284)
+
+    def run_once():
+        samples = results.sample_evidence_mc(
+            num_samples=draws,
+            conditioning="phantom",
+            num_phantoms=prefix,
+            key=key,
+            batch_size=batch_size,
+        )
+        jax.block_until_ready(samples)
+        return samples
+
+    run_once()
+    runtimes = []
+    samples = None
+    for _ in range(repeats):
+        started = time.perf_counter()
+        samples = run_once()
+        runtimes.append(time.perf_counter() - started)
+
+    # Public prefix selection must be exactly the same program as supplying a
+    # physically sliced result. This also guards the benchmark's interpretation
+    # of the compiler plan below.
+    sliced = dataclasses.replace(
+        results,
+        log_L_phantom=results.log_L_phantom[:, :prefix],
+    )
+    expected = sliced.sample_evidence_mc(
+        num_samples=draws,
+        conditioning="phantom",
+        key=key,
+        batch_size=batch_size,
+    )
+    jax.block_until_ready(expected)
+    np.testing.assert_array_equal(
+        samples.log_Z_samples,
+        expected.log_Z_samples,
+    )
+    return {
+        "steady_median_s": statistics.median(runtimes),
+        "steady_min_s": min(runtimes),
+        "steady_max_s": max(runtimes),
+        "log_Z_mean": float(samples.log_Z_mean),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-samples", type=int, default=512)
+    parser.add_argument("--draws", type=int, default=256)
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--repeats", type=int, default=7)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    dimension = 8
+    retained_phantoms = dimension
+    model = _make_model(dimension)
+    sampler = NestedSampler(
+        model=model,
+        root_allocation_degree=64,
+        shell_size=16,
+        max_samples=args.max_samples,
+        initial_capacity=args.max_samples,
+        collect_phantom_samples=True,
+        max_phantom_samples=retained_phantoms,
+        termination_condition=TerminationCondition(
+            max_samples=args.max_samples,
+        ),
+    )
+    run_started = time.perf_counter()
+    state = sampler.run(jax.random.PRNGKey(284))
+    jax.block_until_ready(state)
+    run_s = time.perf_counter() - run_started
+    results = state.to_result().trim()
+    jax.block_until_ready(results)
+
+    records = []
+    for prefix in (1, 4, retained_phantoms):
+        record = {"num_phantoms": prefix}
+        record.update(
+            _compile_summary_kernel(
+                results,
+                prefix,
+                args.draws,
+                args.batch_size,
+            )
+        )
+        record.update(
+            _measure_public_prefix(
+                results,
+                prefix,
+                args.draws,
+                args.batch_size,
+                args.repeats,
+            )
+        )
+        records.append(record)
+
+    output = {
+        "environment": {
+            "backend": jax.default_backend(),
+            "device": str(jax.devices()[0]),
+            "jax_version": jax.__version__,
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "x64": bool(jax.config.jax_enable_x64),
+        },
+        "shape": {
+            "dimension": dimension,
+            "classic_samples": int(results.total_num_samples),
+            "retained_phantoms": results.log_L_phantom.shape[1],
+            "blocks": int(jnp.sum(results.block_data.valid)),
+            "draws": args.draws,
+            "batch_size": args.batch_size,
+        },
+        "nested_sampling_run_s": run_s,
+        "records": records,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, indent=2), encoding="utf-8")
+    print(json.dumps(output, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cicd/coverage_record.json
+++ b/cicd/coverage_record.json
@@ -12,7 +12,8 @@
     "test_mixed_cylinder_crosses_only_the_periodic_seam"
   ],
   "Collecting or retaining phantoms does not change the classic samples, race tree, or classic-conditioned result for the same random run.": [
-    "test_phantom_payload_does_not_change_vector_worker_trajectory"
+    "test_phantom_payload_does_not_change_vector_worker_trajectory",
+    "test_additional_retained_phantoms_leave_classic_run_invariant"
   ],
   "Every nested-sampling contour is strict: a point satisfies contour lambda exactly when its likelihood is greater than lambda.": [
     "test_block_state_rejects_strict_contour_violation",
@@ -81,9 +82,10 @@
   "Increasing the number of independent shrinkage draws makes Monte Carlo evidence summaries converge to the moments implied by the classic shrinkage model.": [
     "test_mc_linear_evidence_moments_match_deterministic_expectations"
   ],
-  "Every phantom cluster is associated with one classic child and contains only retained chain states generated under that child's recorded parent contour.": [
+  "Every phantom cluster is associated with one classic child and contains only a start-prefix of retained chain states generated under that child's recorded parent contour, with the final classic replacement excluded.": [
     "test_each_retained_chain_is_one_kish_cluster",
-    "test_retained_phantoms_are_generated_chain_prefix"
+    "test_retained_phantoms_are_generated_chain_prefix",
+    "test_phantom_capacity_retains_start_prefix_and_excludes_classic"
   ],
   "Dependence within a phantom cluster is preserved by sharing one random cluster weight across all observations and all blocks contributed by that cluster in one shrinkage draw.": [
     "test_deterministic_gamma_helper_reuses_cluster_weights_across_blocks_and_components"
@@ -92,6 +94,9 @@
     "test_sample_evidence_mc_batching_is_reproducible_and_matches_moments",
     "test_sample_evidence_mc_one_batch_preserves_fixed_key_draws",
     "test_batched_summary_preserves_block_models_and_kish_gate"
+  ],
+  "Selecting a shorter phantom-conditioning prefix uses the first requested retained states of every cluster and is equivalent to physically truncating the result's phantom axis to that prefix.": [
+    "test_sample_evidence_mc_prefix_matches_physically_sliced_result"
   ],
   "A phantom contributes to a block only when its cluster parent contour is no stricter than the preceding block contour and the phantom lies beyond that preceding contour.": [
     "test_per_cluster_counts_are_parent_contour_gated_with_equality_and_open_interval",
@@ -188,7 +193,8 @@
     "test_results_sample_mc_shrinkage_rejects_malformed_arrays_before_jit",
     "test_public_sample_mc_shrinkage_rejects_stale_block_likelihoods_before_jit",
     "test_sample_evidence_mc_rejects_invalid_batch_sizes",
-    "test_ellipsoidal_configuration_validation"
+    "test_ellipsoidal_configuration_validation",
+    "test_sample_evidence_mc_rejects_invalid_phantom_prefix"
   ],
   "The default installation supplies plotting dependencies, scientific imports do not eagerly import them, and requesting plotting when they are unavailable fails with an actionable installation remedy.": [
     "test_missing_plotting_dependency_has_actionable_error"

--- a/cicd/non_invariant_test_coverage.json
+++ b/cicd/non_invariant_test_coverage.json
@@ -1,6 +1,26 @@
 {
   "schema_version": 1,
   "tests": {
+    "test_nested_sampler_resolves_and_preserves_phantom_capacity": {
+      "note": "Checks the public retained-capacity configuration, resolved dimension-sized default, and current pytree/checkpoint representation.",
+      "path": "cicd/tests/test_core.py",
+      "reason": "configuration_contract"
+    },
+    "test_phantom_capacity_validation_and_burn_in_deprecation": {
+      "note": "Checks fail-fast bounds for the direct retained capacity and the compatibility warning for the inverse legacy option.",
+      "path": "cicd/tests/test_constrained_sampler.py",
+      "reason": "configuration_contract"
+    },
+    "test_sample_evidence_mc_rejects_prefix_for_classic_conditioning": {
+      "note": "Checks that the explicit classic-conditioning API remains independent of the phantom-prefix option.",
+      "path": "cicd/tests/test_phantom_results.py",
+      "reason": "configuration_contract"
+    },
+    "test_state_sample_evidence_mc_forwards_phantom_prefix": {
+      "note": "Checks parity between the thin State forwarder and the authoritative result-level phantom-prefix implementation.",
+      "path": "cicd/tests/test_phantom_results.py",
+      "reason": "reference_parity"
+    },
     "test_effective_sample_size_kish_uses_posterior_weights": {
       "note": "Checks that the reported posterior ESS is Kish's quantity for the actual posterior weights, independent of evidence moments or phantom states.",
       "path": "cicd/tests/test_stats.py",

--- a/cicd/tests/test_constrained_sampler.py
+++ b/cicd/tests/test_constrained_sampler.py
@@ -133,7 +133,7 @@ def test_slice_continuations_preserve_complete_chain_outputs():
         model=model,
         num_slices=32,
         collect_phantom_samples=True,
-        phantom_burn_in=29,
+        max_phantom_samples=2,
     )
     request = _request(width=8)
     reference = jax.jit(
@@ -153,6 +153,88 @@ def test_slice_continuations_preserve_complete_chain_outputs():
         np.testing.assert_array_equal(np.asarray(actual), np.asarray(expected))
 
 
+def test_phantom_capacity_retains_start_prefix_and_excludes_classic():
+    model = QuadraticModel(centre=jnp.asarray([0.45, 0.55]))
+    seed = SeedPoint(
+        U0=jnp.asarray([0.35, 0.65]),
+        log_L0=model.log_likelihood(jnp.asarray([0.35, 0.65])),
+    )
+    complete_prefix_sampler = UniDimSliceSampler(
+        model=model,
+        num_slices=4,
+        collect_phantom_samples=True,
+    )
+    bounded_sampler = UniDimSliceSampler(
+        model=model,
+        num_slices=4,
+        collect_phantom_samples=True,
+        max_phantom_samples=2,
+    )
+    key = random.PRNGKey(284)
+
+    complete = complete_prefix_sampler.get_sample(
+        key,
+        jnp.asarray(-0.25),
+        seed,
+    )
+    bounded = bounded_sampler.get_sample(
+        key,
+        jnp.asarray(-0.25),
+        seed,
+    )
+
+    # Four generated transitions contain exactly three eligible phantoms; the
+    # fourth output is reserved for the classic replacement. Changing only the
+    # retained width cannot change that replacement or its evaluation count.
+    assert complete[3].log_L.shape == (3,)
+    assert bounded[3].log_L.shape == (2,)
+    np.testing.assert_array_equal(bounded[3].log_L, complete[3].log_L[:2])
+    np.testing.assert_array_equal(
+        bounded[3].U_samples,
+        complete[3].U_samples[:2],
+    )
+    np.testing.assert_array_equal(bounded[0], complete[0])
+    np.testing.assert_array_equal(bounded[1], complete[1])
+    np.testing.assert_array_equal(bounded[2], complete[2])
+    assert not np.array_equal(
+        np.asarray(complete[0]),
+        complete[3].U_samples[-1],
+    )
+
+
+def test_phantom_capacity_validation_and_burn_in_deprecation():
+    model = QuadraticModel(centre=jnp.asarray([0.45, 0.55]))
+
+    with pytest.raises(ValueError, match="positive"):
+        UniDimSliceSampler(
+            model=model,
+            num_slices=4,
+            collect_phantom_samples=True,
+            max_phantom_samples=0,
+        )
+    with pytest.raises(ValueError, match="num_slices - 1"):
+        UniDimSliceSampler(
+            model=model,
+            num_slices=4,
+            collect_phantom_samples=True,
+            max_phantom_samples=4,
+        )
+    with pytest.raises(ValueError, match="collect_phantom_samples"):
+        UniDimSliceSampler(
+            model=model,
+            num_slices=4,
+            max_phantom_samples=1,
+        )
+    with pytest.warns(DeprecationWarning, match="phantom_burn_in"):
+        legacy = UniDimSliceSampler(
+            model=model,
+            num_slices=4,
+            collect_phantom_samples=True,
+            phantom_burn_in=1,
+        )
+    assert legacy.num_phantom() == 2
+
+
 def test_periodic_slice_continuations_preserve_complete_chain_outputs():
     """The pool scheduler preserves each random-chart scalar transition."""
     model = CircularModel(centre=jnp.asarray([0.99, 0.01]))
@@ -160,7 +242,7 @@ def test_periodic_slice_continuations_preserve_complete_chain_outputs():
         model=model,
         num_slices=32,
         collect_phantom_samples=True,
-        phantom_burn_in=29,
+        max_phantom_samples=2,
     )._with_periodic((True, True))
     request = _periodic_request(width=8)
     reference = jax.jit(
@@ -402,7 +484,7 @@ def test_slice_continuations_preserve_gmm_direction_law():
         model=model,
         num_slices=32,
         collect_phantom_samples=True,
-        phantom_burn_in=29,
+        max_phantom_samples=2,
         direction=direction,
     )
     data = empty_sampler_data(num_components=1, dimension=2)
@@ -447,7 +529,7 @@ def test_slice_continuations_do_not_execute_scheduler_padding():
         model=model,
         num_slices=32,
         collect_phantom_samples=True,
-        phantom_burn_in=30,
+        max_phantom_samples=1,
     )
     request = _request(width=8)
     padded_request = dataclasses.replace(

--- a/cicd/tests/test_constrained_sampler.py
+++ b/cicd/tests/test_constrained_sampler.py
@@ -205,6 +205,14 @@ def test_phantom_capacity_retains_start_prefix_and_excludes_classic():
 def test_phantom_capacity_validation_and_burn_in_deprecation():
     model = QuadraticModel(centre=jnp.asarray([0.45, 0.55]))
 
+    for non_python_integer in (np.int64(2), jnp.asarray(2)):
+        with pytest.raises(TypeError, match="Python integer"):
+            UniDimSliceSampler(
+                model=model,
+                num_slices=4,
+                collect_phantom_samples=True,
+                max_phantom_samples=non_python_integer,
+            )
     with pytest.raises(ValueError, match="positive"):
         UniDimSliceSampler(
             model=model,

--- a/cicd/tests/test_core.py
+++ b/cicd/tests/test_core.py
@@ -883,6 +883,43 @@ def test_nested_sampler_resolves_and_preserves_phantom_capacity():
     assert bounded.max_phantom_samples == 5
     assert bounded.sampler.num_phantom() == 5
 
+    # NestedSampler owns the high-level D-sized default even when the caller
+    # supplies an otherwise unbounded built-in slice sampler. Direct low-level
+    # use remains capable of retaining every eligible transition.
+    custom_unbounded = UniDimSliceSampler(
+        model=model,
+        num_slices=10,
+        collect_phantom_samples=True,
+    )
+    assert custom_unbounded.num_phantom() == 9
+    custom_default = NestedSampler(model=model, sampler=custom_unbounded)
+    assert custom_default.max_phantom_samples == 2
+    assert custom_default.sampler.num_phantom() == 2
+
+    custom_explicit = NestedSampler(
+        model=model,
+        sampler=custom_unbounded,
+        max_phantom_samples=np.int64(4),
+    )
+    assert custom_explicit.max_phantom_samples is int(
+        custom_explicit.max_phantom_samples
+    )
+    assert custom_explicit.max_phantom_samples == 4
+    assert custom_explicit.sampler.num_phantom() == 4
+
+    sampler_capacity = dataclasses.replace(
+        custom_unbounded,
+        max_phantom_samples=5,
+    )
+    sampler_precedence = NestedSampler(model=model, sampler=sampler_capacity)
+    assert sampler_precedence.max_phantom_samples == 5
+    with pytest.raises(ValueError, match="disagrees"):
+        NestedSampler(
+            model=model,
+            sampler=sampler_capacity,
+            max_phantom_samples=4,
+        )
+
     restored_sampler = pickle.loads(pickle.dumps(bounded))
     assert restored_sampler.max_phantom_samples == 5
     assert restored_sampler.sampler.num_phantom() == 5

--- a/cicd/tests/test_core.py
+++ b/cicd/tests/test_core.py
@@ -864,3 +864,95 @@ def test_retained_phantoms_are_generated_chain_prefix():
     chain = jnp.asarray([10.0, 20.0, 30.0, 40.0])
     retained = _take_phantom_prefix(chain, 2)
     np.testing.assert_array_equal(np.asarray(retained), [10.0, 20.0])
+
+
+def test_nested_sampler_resolves_and_preserves_phantom_capacity():
+    model = TwoDimensionalModel()
+    default = NestedSampler(
+        model=model,
+        collect_phantom_samples=True,
+    )
+    bounded = NestedSampler(
+        model=model,
+        collect_phantom_samples=True,
+        max_phantom_samples=5,
+    )
+
+    assert default.max_phantom_samples == 2
+    assert default.sampler.num_phantom() == 2
+    assert bounded.max_phantom_samples == 5
+    assert bounded.sampler.num_phantom() == 5
+
+    restored_sampler = pickle.loads(pickle.dumps(bounded))
+    assert restored_sampler.max_phantom_samples == 5
+    assert restored_sampler.sampler.num_phantom() == 5
+
+    state = bounded.initialise(jax.random.PRNGKey(284))
+    restored_state = pickle.loads(pickle.dumps(state))
+    assert restored_state.samples.phantom_samples.log_L.shape[1] == 5
+
+    with pytest.raises(ValueError, match="collect_phantom_samples"):
+        NestedSampler(model=model, max_phantom_samples=1)
+    with pytest.raises(ValueError, match="num_slices - 1"):
+        NestedSampler(
+            model=model,
+            collect_phantom_samples=True,
+            max_phantom_samples=10,
+        )
+
+
+def test_additional_retained_phantoms_leave_classic_run_invariant():
+    model = TwoDimensionalModel()
+    common = {
+        "model": model,
+        "collect_phantom_samples": True,
+        "root_allocation_degree": 4,
+        "shell_size": 2,
+        "max_samples": 6,
+        "initial_capacity": 6,
+        "termination_condition": TerminationCondition(max_samples=6),
+    }
+    short = NestedSampler(max_phantom_samples=1, **common)
+    long = NestedSampler(max_phantom_samples=9, **common)
+    key = jax.random.PRNGKey(1284)
+
+    short_state = short.run(key)
+    long_state = long.run(key)
+
+    for short_value, long_value in (
+        (short_state.num_samples, long_state.num_samples),
+        (short_state.termination_reason, long_state.termination_reason),
+        (
+            short_state.samples.log_L_constraints,
+            long_state.samples.log_L_constraints,
+        ),
+        (
+            short_state.samples.log_likelihoods,
+            long_state.samples.log_likelihoods,
+        ),
+        (short_state.samples.U_samples, long_state.samples.U_samples),
+        (short_state.samples.out_degree, long_state.samples.out_degree),
+        (
+            short_state.samples.num_likelihood_evaluations,
+            long_state.samples.num_likelihood_evaluations,
+        ),
+    ):
+        np.testing.assert_array_equal(short_value, long_value)
+
+    short_result = short_state.to_result().trim()
+    long_result = long_state.to_result().trim()
+    evidence_key = jax.random.PRNGKey(2284)
+    short_evidence = short_result.sample_evidence_mc(
+        num_samples=16,
+        conditioning="classic",
+        key=evidence_key,
+    )
+    long_evidence = long_result.sample_evidence_mc(
+        num_samples=16,
+        conditioning="classic",
+        key=evidence_key,
+    )
+    np.testing.assert_array_equal(
+        short_evidence.log_Z_samples,
+        long_evidence.log_Z_samples,
+    )

--- a/cicd/tests/test_distributed_runtime.py
+++ b/cicd/tests/test_distributed_runtime.py
@@ -843,7 +843,7 @@ def test_phantom_payload_does_not_change_vector_worker_trajectory(tmp_path):
                 model=model,
                 num_slices=2,
                 collect_phantom_samples=collect_phantoms,
-                phantom_burn_in=0,
+                max_phantom_samples=(1 if collect_phantoms else None),
             )
             runner = DistributedNestedSampler(
                 model=model,
@@ -969,7 +969,7 @@ def test_real_pool_runs_scalar_vmap_retries_and_cli_lifecycle(tmp_path):
             model=model,
             num_slices=2,
             collect_phantom_samples=True,
-            phantom_burn_in=0,
+            max_phantom_samples=1,
         )
         distributed = DistributedNestedSampler(
             model=model,

--- a/cicd/tests/test_phantom_results.py
+++ b/cicd/tests/test_phantom_results.py
@@ -594,6 +594,126 @@ def test_sample_evidence_mc_one_batch_preserves_fixed_key_draws():
     )
 
 
+def test_sample_evidence_mc_prefix_matches_physically_sliced_result():
+    one_phantom = _make_single_block_gamma_public_result()
+    retained = dataclasses.replace(
+        one_phantom,
+        log_L_phantom=jnp.concatenate(
+            [
+                one_phantom.log_L_phantom,
+                one_phantom.log_L_phantom - 0.25,
+                one_phantom.log_L_phantom + 0.25,
+            ],
+            axis=1,
+        ),
+        total_phantom_samples=3 * one_phantom.total_phantom_samples,
+    )
+    physically_sliced = dataclasses.replace(
+        retained,
+        log_L_phantom=retained.log_L_phantom[:, :2],
+    )
+    key = jax.random.PRNGKey(284)
+
+    selected = retained.sample_evidence_mc(
+        num_samples=32,
+        conditioning="phantom",
+        num_phantoms=2,
+        key=key,
+        batch_size=11,
+        diagnostics=True,
+    )
+    expected = physically_sliced.sample_evidence_mc(
+        num_samples=32,
+        conditioning="phantom",
+        key=key,
+        batch_size=11,
+        diagnostics=True,
+    )
+    all_default = retained.sample_evidence_mc(
+        num_samples=32,
+        conditioning="phantom",
+        key=key,
+        batch_size=11,
+    )
+    all_explicit = retained.sample_evidence_mc(
+        num_samples=32,
+        conditioning="phantom",
+        num_phantoms=3,
+        key=key,
+        batch_size=11,
+    )
+
+    for actual, reference in zip(
+        jax.tree.leaves(selected),
+        jax.tree.leaves(expected),
+        strict=True,
+    ):
+        np.testing.assert_array_equal(actual, reference)
+    for actual, reference in zip(
+        jax.tree.leaves(all_default),
+        jax.tree.leaves(all_explicit),
+        strict=True,
+    ):
+        np.testing.assert_array_equal(actual, reference)
+
+
+@pytest.mark.parametrize("num_phantoms", [0, -1, 4])
+def test_sample_evidence_mc_rejects_invalid_phantom_prefix(num_phantoms):
+    one_phantom = _make_single_block_gamma_public_result()
+    retained = dataclasses.replace(
+        one_phantom,
+        log_L_phantom=jnp.tile(one_phantom.log_L_phantom, (1, 3)),
+    )
+
+    with pytest.raises(ValueError, match="num_phantoms"):
+        retained.sample_evidence_mc(
+            num_samples=4,
+            conditioning="phantom",
+            num_phantoms=num_phantoms,
+            key=jax.random.PRNGKey(1284),
+        )
+
+
+def test_sample_evidence_mc_rejects_prefix_for_classic_conditioning():
+    results = _make_single_block_gamma_public_result()
+
+    with pytest.raises(ValueError, match="only valid with phantom"):
+        results.sample_evidence_mc(
+            num_samples=4,
+            conditioning="classic",
+            num_phantoms=1,
+            key=jax.random.PRNGKey(2284),
+        )
+
+
+def test_state_sample_evidence_mc_forwards_phantom_prefix():
+    state = _run_mixed_validity_probe()
+    results = state.to_result().trim()
+    key = jax.random.PRNGKey(3284)
+
+    from_state = state.sample_evidence_mc(
+        num_samples=8,
+        conditioning="phantom",
+        num_phantoms=1,
+        key=key,
+        C_min=1,
+    )
+    from_results = results.sample_evidence_mc(
+        num_samples=8,
+        conditioning="phantom",
+        num_phantoms=1,
+        key=key,
+        C_min=1,
+    )
+
+    for actual, expected in zip(
+        jax.tree.leaves(from_state),
+        jax.tree.leaves(from_results),
+        strict=True,
+    ):
+        np.testing.assert_array_equal(actual, expected)
+
+
 @pytest.mark.parametrize("batch_size", [0, -1])
 def test_sample_evidence_mc_rejects_invalid_batch_sizes(batch_size):
     results = _make_single_block_gamma_public_result()

--- a/docs/design/INVARIANTS.md
+++ b/docs/design/INVARIANTS.md
@@ -103,8 +103,9 @@ The exact text following each `- Invariant:` prefix is the stable key used by
 
 - Invariant: Phantom samples are auxiliary constrained-prior observations and never participate
   as arrivals or lineages in the classic race tree.
-- Invariant: Every phantom cluster is associated with one classic child and contains only
-  retained chain states generated under that child's recorded parent contour.
+- Invariant: Every phantom cluster is associated with one classic child and contains only a
+  start-prefix of retained chain states generated under that child's recorded parent contour,
+  with the final classic replacement excluded.
 - Invariant: Retained phantom states have the constrained-prior marginal distribution of their
   cluster's parent contour.
 - Invariant: Dependence within a phantom cluster is preserved by sharing one random cluster
@@ -112,6 +113,9 @@ The exact text following each `- Invariant:` prefix is the stable key used by
   draw.
 - Invariant: Changing how independent final Monte Carlo draws are batched does not change
   phantom-cluster identity, the joint shrinkage law, or the evidence distribution.
+- Invariant: Selecting a shorter phantom-conditioning prefix uses the first requested retained
+  states of every cluster and is equivalent to physically truncating the result's phantom axis
+  to that prefix.
 - Invariant: Phantom clusters treated as independent contributions originate from independently
   initialized stationary chains.
 - Invariant: A phantom contributes to a block only when its cluster parent contour is no

--- a/docs/design/REQUIREMENTS.md
+++ b/docs/design/REQUIREMENTS.md
@@ -30,6 +30,11 @@ properties that must hold independently of implementation live in
 - Requirement: User-facing state and result objects carry thin methods for operations naturally
   applied to their data, so scientific users can work object-orientedly without moving core
   orchestration into those containers.
+- Requirement: The default nested sampler exposes a direct maximum retained-phantom capacity;
+  its automatic capacity is the smaller of one model dimension and `num_slices - 1`.
+- Requirement: Evidence-time phantom prefix selection is independent of retained storage;
+  `None` uses all saved states and an explicit positive count physically slices the start-prefix
+  before the compiled Monte Carlo kernel so an unused suffix adds no device work or memory.
 - Requirement: `NestedSamplerResults` keeps the commonly used evidence, posterior, and sample
   fields visually primary and stores block-aligned implementation detail in one `BlockData`
   field.

--- a/docs/user-guide/phantom_conditioning.rst
+++ b/docs/user-guide/phantom_conditioning.rst
@@ -27,7 +27,9 @@ The final transition remains the classic replacement and is never stored as a
 phantom. With no explicit bound, the default slice sampler retains up to one
 model dimension of states, capped by ``num_slices - 1``. A larger bound can be
 useful for later sensitivity checks, at the cost of wider result and checkpoint
-arrays.
+arrays. The same dimension-sized default is resolved when an otherwise
+unbounded ``UniDimSliceSampler`` is supplied to ``NestedSampler``. Set a direct
+capacity on that low-level sampler when it should take precedence instead.
 
 Conditioning owns computation
 -----------------------------

--- a/docs/user-guide/phantom_conditioning.rst
+++ b/docs/user-guide/phantom_conditioning.rst
@@ -1,0 +1,61 @@
+Phantom collection and evidence conditioning
+============================================
+
+Phantom states are eligible intermediate transitions from a constrained slice
+chain. They condition the Monte Carlo shrinkage model, but they are not classic
+race-tree samples and do not contribute posterior coordinates or posterior
+effective sample size.
+
+Collection owns memory
+----------------------
+
+Enable collection on :class:`jaxns.core.NestedSampler` and optionally bound
+the static phantom axis:
+
+.. code-block:: python
+
+   nested_sampler = NestedSampler(
+       model=model,
+       collect_phantom_samples=True,
+       max_phantom_samples=8,
+   )
+   state = nested_sampler.run(key=jax.random.PRNGKey(0))
+   results = state.to_result().trim()
+
+The sampler stores the first eligible transitions from each generated chain.
+The final transition remains the classic replacement and is never stored as a
+phantom. With no explicit bound, the default slice sampler retains up to one
+model dimension of states, capped by ``num_slices - 1``. A larger bound can be
+useful for later sensitivity checks, at the cost of wider result and checkpoint
+arrays.
+
+Conditioning owns computation
+-----------------------------
+
+The completed state or results can reuse any leading part of the retained
+prefix:
+
+.. code-block:: python
+
+   all_saved = results.sample_evidence_mc(
+       num_samples=4096,
+       conditioning="phantom",
+       num_phantoms=None,
+       key=jax.random.PRNGKey(1),
+   )
+   first_four = results.sample_evidence_mc(
+       num_samples=4096,
+       conditioning="phantom",
+       num_phantoms=4,
+       key=jax.random.PRNGKey(1),
+   )
+   classic = results.sample_evidence_mc(
+       num_samples=4096,
+       conditioning="classic",
+       key=jax.random.PRNGKey(1),
+   )
+
+``None`` uses all saved states. An explicit positive count uses
+``log_L_phantom[:, :num_phantoms]`` before the MC kernel is compiled, so an
+unused suffix does not add device work. Classic conditioning is independent of
+phantom storage and remains the explicit zero-phantom path.

--- a/src/jaxns/constrained_sampler.py
+++ b/src/jaxns/constrained_sampler.py
@@ -191,6 +191,23 @@ class AbstractSampler(ABC):
             )
         return self
 
+    def _with_phantom_capacity(
+            self,
+            max_phantom_samples: int | None,
+            dimension: int,
+    ) -> AbstractSampler:
+        """Apply a high-level retained capacity through an explicit API."""
+        del dimension
+        if (
+            max_phantom_samples is not None
+            and max_phantom_samples != self.num_phantom()
+        ):
+            raise ValueError(
+                "max_phantom_samples must match the fixed capacity of a "
+                "custom sampler."
+            )
+        return self
+
     def validate_core(self, dimension: int) -> None:
         """Validate sampler compatibility with the current race-tree core."""
         del dimension
@@ -288,7 +305,13 @@ class UniDimSliceSampler(AbstractSampler, PureDataclassPytree):
         ])
 
     def __post_init__(self):
-        if self.num_slices < 1:
+        try:
+            num_slices = operator.index(self.num_slices)
+        except TypeError as error:
+            raise TypeError("num_slices must be a Python integer.") from error
+        if num_slices is not self.num_slices:
+            raise TypeError("num_slices must be a Python integer.")
+        if num_slices < 1:
             raise ValueError(f"num_slices should be >= 1, got {self.num_slices}.")
         if self.gradient_guided:
             warnings.warn("Gradient guided slice sampler is experimental and will likely change.")
@@ -314,8 +337,12 @@ class UniDimSliceSampler(AbstractSampler, PureDataclassPytree):
                 )
             except TypeError as error:
                 raise TypeError(
-                    "max_phantom_samples must be an integer or None."
+                    "max_phantom_samples must be a Python integer or None."
                 ) from error
+            if max_phantom_samples is not self.max_phantom_samples:
+                raise TypeError(
+                    "max_phantom_samples must be a Python integer or None."
+                )
             if max_phantom_samples < 1:
                 raise ValueError("max_phantom_samples must be positive.")
             if max_phantom_samples > self.num_slices - 1:
@@ -335,8 +362,12 @@ class UniDimSliceSampler(AbstractSampler, PureDataclassPytree):
                 phantom_burn_in = operator.index(self.phantom_burn_in)
             except TypeError as error:
                 raise TypeError(
-                    "phantom_burn_in must be an integer or None."
+                    "phantom_burn_in must be a Python integer or None."
                 ) from error
+            if phantom_burn_in is not self.phantom_burn_in:
+                raise TypeError(
+                    "phantom_burn_in must be a Python integer or None."
+                )
             if not 0 <= phantom_burn_in <= self.num_slices - 1:
                 raise ValueError(
                     "phantom_burn_in must be in [0, num_slices - 1]."
@@ -375,6 +406,53 @@ class UniDimSliceSampler(AbstractSampler, PureDataclassPytree):
     ) -> UniDimSliceSampler:
         """Install the model-derived static topology on this sampler."""
         return dataclasses.replace(self, _periodic=periodic)
+
+    def _with_phantom_capacity(
+            self,
+            max_phantom_samples: int | None,
+            dimension: int,
+    ) -> UniDimSliceSampler:
+        """Resolve NestedSampler's default or explicit retained capacity."""
+        if not self.collect_phantom_samples:
+            if max_phantom_samples is not None:
+                raise ValueError(
+                    "max_phantom_samples requires "
+                    "collect_phantom_samples=True."
+                )
+            return self
+        if max_phantom_samples is None:
+            if (
+                self.max_phantom_samples is not None
+                or self.phantom_burn_in is not None
+            ):
+                # A capacity set directly on the low-level sampler is already
+                # explicit and takes precedence over the high-level default.
+                return self
+            max_phantom_samples = min(dimension, self.num_slices - 1)
+        elif (
+            self.max_phantom_samples is not None
+            and max_phantom_samples != self.max_phantom_samples
+        ):
+            raise ValueError(
+                "max_phantom_samples disagrees with the capacity configured "
+                "on the custom slice sampler."
+            )
+        elif (
+            self.phantom_burn_in is not None
+            and max_phantom_samples != self.num_phantom()
+        ):
+            raise ValueError(
+                "max_phantom_samples disagrees with the deprecated "
+                "phantom_burn_in capacity."
+            )
+        if max_phantom_samples == 0:
+            return self
+        if max_phantom_samples == self.num_phantom():
+            return self
+        return dataclasses.replace(
+            self,
+            max_phantom_samples=max_phantom_samples,
+        )
 
     def validate_core(self, dimension: int) -> None:
         if not self.no_step_out:

--- a/src/jaxns/constrained_sampler.py
+++ b/src/jaxns/constrained_sampler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import operator
 import warnings
 from abc import ABC, abstractmethod
 from typing import Any, NamedTuple
@@ -253,7 +254,12 @@ class UniDimSliceSampler(AbstractSampler, PureDataclassPytree):
             Otherwise, uses a doubling procedure (exponentially finding bracket).
             Note: Perfect is a misnomer, as perfection also depends on the number of slices between acceptance.
         gradient_guided: if true then do HMC with householder reflections.
-        collect_phantom_samples: if true, then collect phantom samples
+        collect_phantom_samples: Whether to retain intermediate chain states.
+        max_phantom_samples: Maximum number of intermediate states retained
+            from the start of each chain. ``None`` retains every eligible
+            transition. The final transition is always the classic sample.
+        phantom_burn_in: Deprecated inverse spelling for retained phantom
+            capacity. Use ``max_phantom_samples`` instead.
     """
 
     model: Model
@@ -263,6 +269,7 @@ class UniDimSliceSampler(AbstractSampler, PureDataclassPytree):
     collect_phantom_samples: bool = False
     phantom_burn_in: int | None = None
     direction: EllipsoidalDirection | None = None
+    max_phantom_samples: int | None = None
     # Internal scalar topology derived from JAXCTX metadata by NestedSampler.
     # Keeping this private avoids a second user-supplied flat-index API.
     _periodic: tuple[bool, ...] = ()
@@ -274,25 +281,79 @@ class UniDimSliceSampler(AbstractSampler, PureDataclassPytree):
             'no_step_out',
             'gradient_guided',
             'collect_phantom_samples',
+            'max_phantom_samples',
             'phantom_burn_in',
             'direction',
             '_periodic',
         ])
 
-    def _check(self):
+    def __post_init__(self):
         if self.num_slices < 1:
             raise ValueError(f"num_slices should be >= 1, got {self.num_slices}.")
         if self.gradient_guided:
             warnings.warn("Gradient guided slice sampler is experimental and will likely change.")
+        if (
+            self.max_phantom_samples is not None
+            and self.phantom_burn_in is not None
+        ):
+            raise ValueError(
+                "max_phantom_samples and the deprecated phantom_burn_in "
+                "cannot both be specified."
+            )
+        if (
+            not self.collect_phantom_samples
+            and self.max_phantom_samples is not None
+        ):
+            raise ValueError(
+                "A phantom capacity requires collect_phantom_samples=True."
+            )
+        if self.max_phantom_samples is not None:
+            try:
+                max_phantom_samples = operator.index(
+                    self.max_phantom_samples
+                )
+            except TypeError as error:
+                raise TypeError(
+                    "max_phantom_samples must be an integer or None."
+                ) from error
+            if max_phantom_samples < 1:
+                raise ValueError("max_phantom_samples must be positive.")
+            if max_phantom_samples > self.num_slices - 1:
+                raise ValueError(
+                    "max_phantom_samples cannot exceed num_slices - 1: "
+                    f"got {max_phantom_samples} for "
+                    f"num_slices={self.num_slices}."
+                )
+        if self.phantom_burn_in is not None:
+            warnings.warn(
+                "phantom_burn_in is deprecated; specify the direct "
+                "max_phantom_samples capacity instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            try:
+                phantom_burn_in = operator.index(self.phantom_burn_in)
+            except TypeError as error:
+                raise TypeError(
+                    "phantom_burn_in must be an integer or None."
+                ) from error
+            if not 0 <= phantom_burn_in <= self.num_slices - 1:
+                raise ValueError(
+                    "phantom_burn_in must be in [0, num_slices - 1]."
+                )
 
     def num_phantom(self) -> int:
-        if self.collect_phantom_samples:
-            if self.phantom_burn_in is None:
-                burn_in = int(self.num_slices * 0.1)
-            else:
-                burn_in = self.phantom_burn_in
-            return self.num_slices - 1 - burn_in
-        return 0
+        if not self.collect_phantom_samples:
+            return 0
+        if self.phantom_burn_in is not None:
+            return self.num_slices - 1 - operator.index(
+                self.phantom_burn_in
+            )
+        if self.max_phantom_samples is not None:
+            return operator.index(self.max_phantom_samples)
+        # A low-level sampler with no explicit memory bound retains the whole
+        # eligible prefix. NestedSampler supplies its dimension-sized default.
+        return self.num_slices - 1
 
     def uses_adaptive_directions(self) -> bool:
         return self.direction is not None

--- a/src/jaxns/core.py
+++ b/src/jaxns/core.py
@@ -135,52 +135,25 @@ class NestedSampler(PureDataclassPytree):
         sampler = self.sampler
         if sampler is None:
             num_slices = max(1, 5 * U_ndims)
-            if self.collect_phantom_samples:
-                if self.max_phantom_samples is None:
-                    # One dimension of stationary transitions is a useful
-                    # default without retaining the complete 5D slice chain.
-                    max_phantom_samples = min(
-                        U_ndims,
-                        num_slices - 1,
-                    )
-                else:
-                    try:
-                        max_phantom_samples = operator.index(
-                            self.max_phantom_samples
-                        )
-                    except TypeError as error:
-                        raise TypeError(
-                            "max_phantom_samples must be an integer or None."
-                        ) from error
-            else:
-                if self.max_phantom_samples is not None:
-                    raise ValueError(
-                        "max_phantom_samples requires "
-                        "collect_phantom_samples=True."
-                    )
-                max_phantom_samples = None
             sampler = UniDimSliceSampler(
                 model=self.model,
                 num_slices=num_slices,
                 no_step_out=True,
                 gradient_guided=False,
                 collect_phantom_samples=self.collect_phantom_samples,
-                max_phantom_samples=max_phantom_samples,
             )
-        elif self.max_phantom_samples is not None:
+        max_phantom_samples = self.max_phantom_samples
+        if max_phantom_samples is not None:
             try:
-                requested_phantoms = operator.index(
-                    self.max_phantom_samples
-                )
+                max_phantom_samples = operator.index(max_phantom_samples)
             except TypeError as error:
                 raise TypeError(
                     "max_phantom_samples must be an integer or None."
                 ) from error
-            if requested_phantoms != sampler.num_phantom():
-                raise ValueError(
-                    "max_phantom_samples must match the capacity configured "
-                    "on a custom sampler."
-                )
+        sampler = sampler._with_phantom_capacity(
+            max_phantom_samples,
+            U_ndims,
+        )
         sampler = sampler._with_periodic(periodic)
         sampler.validate_core(U_ndims)
 

--- a/src/jaxns/core.py
+++ b/src/jaxns/core.py
@@ -1,6 +1,7 @@
 """Depth-first nested sampling core described by the paper."""
 
 import dataclasses
+import operator
 from collections.abc import Callable
 from contextlib import nullcontext
 from pathlib import Path
@@ -45,6 +46,12 @@ class NestedSampler(PureDataclassPytree):
     physical buffers grow only up to it. Set ``unlimited_samples=True`` to opt
     into unbounded geometric growth and its associated memory use and one-time
     recompilation pause for each new shape.
+
+    When ``collect_phantom_samples=True``, ``max_phantom_samples`` bounds the
+    leading stationary chain prefix stored per classic replacement. ``None``
+    resolves to ``min(model dimension, num_slices - 1)`` for the default slice
+    sampler. The retained width is independent of the shorter prefix that can
+    later be selected by ``sample_evidence_mc``.
     """
 
     model: Model
@@ -61,6 +68,7 @@ class NestedSampler(PureDataclassPytree):
     # likelihoods only; high-dimensional phantom coordinates are not retained.
     store_phantom_samples: bool = False
     collect_phantom_samples: bool = False
+    max_phantom_samples: int | None = None
     allocation_target: Literal[
         "uniform",
         "evidence_improving",
@@ -127,16 +135,52 @@ class NestedSampler(PureDataclassPytree):
         sampler = self.sampler
         if sampler is None:
             num_slices = max(1, 5 * U_ndims)
-            retained_phantoms = U_ndims if self.collect_phantom_samples else 0
-            phantom_burn_in = num_slices - 1 - retained_phantoms
+            if self.collect_phantom_samples:
+                if self.max_phantom_samples is None:
+                    # One dimension of stationary transitions is a useful
+                    # default without retaining the complete 5D slice chain.
+                    max_phantom_samples = min(
+                        U_ndims,
+                        num_slices - 1,
+                    )
+                else:
+                    try:
+                        max_phantom_samples = operator.index(
+                            self.max_phantom_samples
+                        )
+                    except TypeError as error:
+                        raise TypeError(
+                            "max_phantom_samples must be an integer or None."
+                        ) from error
+            else:
+                if self.max_phantom_samples is not None:
+                    raise ValueError(
+                        "max_phantom_samples requires "
+                        "collect_phantom_samples=True."
+                    )
+                max_phantom_samples = None
             sampler = UniDimSliceSampler(
                 model=self.model,
                 num_slices=num_slices,
                 no_step_out=True,
                 gradient_guided=False,
                 collect_phantom_samples=self.collect_phantom_samples,
-                phantom_burn_in=max(0, phantom_burn_in),
+                max_phantom_samples=max_phantom_samples,
             )
+        elif self.max_phantom_samples is not None:
+            try:
+                requested_phantoms = operator.index(
+                    self.max_phantom_samples
+                )
+            except TypeError as error:
+                raise TypeError(
+                    "max_phantom_samples must be an integer or None."
+                ) from error
+            if requested_phantoms != sampler.num_phantom():
+                raise ValueError(
+                    "max_phantom_samples must match the capacity configured "
+                    "on a custom sampler."
+                )
         sampler = sampler._with_periodic(periodic)
         sampler.validate_core(U_ndims)
 
@@ -180,6 +224,9 @@ class NestedSampler(PureDataclassPytree):
         self.shell_size = int(shell_size)
         self.max_samples = max_samples
         self.sampler = sampler
+        # Publish the resolved static width, including custom samplers, so a
+        # caller can distinguish retained capacity from later MC prefix use.
+        self.max_phantom_samples = int(sampler.num_phantom())
         self.termination_condition = termination_condition
         self.initial_capacity = initial_capacity
         self.delta_K = int(delta_K)
@@ -196,6 +243,7 @@ class NestedSampler(PureDataclassPytree):
                 "batch_size",
                 "store_phantom_samples",
                 "collect_phantom_samples",
+                "max_phantom_samples",
                 "allocation_target",
                 "delta_K",
                 "initial_capacity",

--- a/src/jaxns/distributed_core.py
+++ b/src/jaxns/distributed_core.py
@@ -500,6 +500,7 @@ class DistributedNestedSampler:
         "coordinator_port",
         "delta_K",
         "initial_capacity",
+        "max_phantom_samples",
         "max_samples",
         "model",
         "params",
@@ -525,6 +526,7 @@ class DistributedNestedSampler:
             termination_condition: TerminationCondition | None = None,
             store_phantom_samples: bool = False,
             collect_phantom_samples: bool = False,
+            max_phantom_samples: int | None = None,
             allocation_target: Literal[
                 "uniform",
                 "evidence_improving",
@@ -549,6 +551,7 @@ class DistributedNestedSampler:
         self.termination_condition = termination_condition
         self.store_phantom_samples = store_phantom_samples
         self.collect_phantom_samples = collect_phantom_samples
+        self.max_phantom_samples = max_phantom_samples
         self.allocation_target = allocation_target
         self.delta_K = delta_K
         self.initial_capacity = initial_capacity
@@ -590,6 +593,7 @@ class DistributedNestedSampler:
             termination_condition=self.termination_condition,
             store_phantom_samples=self.store_phantom_samples,
             collect_phantom_samples=self.collect_phantom_samples,
+            max_phantom_samples=self.max_phantom_samples,
             allocation_target=self.allocation_target,
             delta_K=delta_K,
             initial_capacity=initial_capacity,
@@ -600,6 +604,7 @@ class DistributedNestedSampler:
         self.root_allocation_degree = core.root_allocation_degree
         self.max_samples = core.max_samples
         self.sampler = core.sampler
+        self.max_phantom_samples = core.max_phantom_samples
         self.termination_condition = core.termination_condition
         self.delta_K = core.delta_K
         self.initial_capacity = core.initial_capacity

--- a/src/jaxns/results.py
+++ b/src/jaxns/results.py
@@ -1,4 +1,5 @@
 import dataclasses
+import operator
 from collections.abc import Callable
 from functools import partial
 from pathlib import Path
@@ -388,6 +389,7 @@ class NestedSamplerResults(PureDataclassPytree):
             *,
             conditioning: EvidenceConditioning,
             key: PRNGKey,
+            num_phantoms: int | None = None,
             batch_size: int | None = None,
             C_min: float = 20,
             diagnostics: bool = False,
@@ -399,6 +401,9 @@ class NestedSamplerResults(PureDataclassPytree):
             conditioning: ``"classic"`` ignores retained phantoms;
                 ``"phantom"`` uses retained clusters subject to the Kish gate.
             key: Explicit JAX PRNG key.
+            num_phantoms: Number of retained states to use from the start of
+                each phantom cluster. ``None`` uses every saved state. This is
+                only valid with ``conditioning="phantom"``.
             batch_size: Maximum number of draws evaluated at once. ``None``
                 uses an automatically bounded batch of at most 64 draws.
             C_min: Minimum participating-cluster Kish count for conditioning.
@@ -414,14 +419,48 @@ class NestedSamplerResults(PureDataclassPytree):
             raise ValueError(
                 "conditioning must be explicitly 'classic' or 'phantom'."
             )
-        if conditioning == "phantom" and self.log_L_phantom.shape[1] == 0:
-            raise ValueError(
-                "Phantom conditioning was requested, but no phantom slots "
-                "were collected."
+        results = self
+        if conditioning == "classic":
+            if num_phantoms is not None:
+                raise ValueError(
+                    "num_phantoms is only valid with phantom conditioning."
+                )
+        else:
+            retained_phantoms = self.log_L_phantom.shape[1]
+            if retained_phantoms == 0:
+                raise ValueError(
+                    "Phantom conditioning was requested, but no phantom "
+                    "slots were collected."
+                )
+            if num_phantoms is None:
+                num_phantoms = retained_phantoms
+            else:
+                try:
+                    num_phantoms = operator.index(num_phantoms)
+                except TypeError as error:
+                    raise TypeError(
+                        "num_phantoms must be an integer or None."
+                    ) from error
+                if num_phantoms <= 0:
+                    raise ValueError(
+                        "num_phantoms must be positive for phantom "
+                        "conditioning."
+                    )
+                if num_phantoms > retained_phantoms:
+                    raise ValueError(
+                        "num_phantoms cannot exceed the retained phantom "
+                        f"capacity of {retained_phantoms}."
+                    )
+            # This physical prefix slice changes the static P axis seen by
+            # the jitted MC kernel. An unused suffix therefore contributes no
+            # device work or compiler memory, rather than merely being masked.
+            results = dataclasses.replace(
+                self,
+                log_L_phantom=self.log_L_phantom[:, :num_phantoms],
             )
         if batch_size is None:
             batch_size = min(num_samples, DEFAULT_MC_BATCH_SIZE)
-        return self.sample_mc_shrinkage(
+        return results.sample_mc_shrinkage(
             num_samples=num_samples,
             batch_size=batch_size,
             key=key,

--- a/src/jaxns/state.py
+++ b/src/jaxns/state.py
@@ -132,6 +132,7 @@ class State(PureDataclassPytree):
             *,
             conditioning: Literal["classic", "phantom"],
             key: jax.Array,
+            num_phantoms: int | None = None,
             batch_size: int | None = None,
             C_min: float = 20,
             diagnostics: bool = False,
@@ -147,6 +148,8 @@ class State(PureDataclassPytree):
             conditioning: Whether to use only the classic race or condition
                 on retained phantom clusters.
             key: Explicit JAX random key.
+            num_phantoms: Number of retained states to use from the start of
+                each phantom cluster. ``None`` uses every saved state.
             batch_size: Maximum simultaneous evidence draws. ``None`` uses
                 the bounded result-level default.
             C_min: Minimum participating-cluster Kish count.
@@ -159,6 +162,7 @@ class State(PureDataclassPytree):
             num_samples=num_samples,
             conditioning=conditioning,
             key=key,
+            num_phantoms=num_phantoms,
             batch_size=batch_size,
             C_min=C_min,
             diagnostics=diagnostics,


### PR DESCRIPTION
## Summary
- replace inverse phantom burn-in configuration with direct `max_phantom_samples`, retaining the generated-chain start-prefix and excluding the final classic replacement
- resolve the `NestedSampler` default retained capacity to `min(model dimension, num_slices - 1)` for both its default sampler and an otherwise unbounded supplied `UniDimSliceSampler`; an explicit low-level capacity takes precedence, while standalone unbounded slice samplers retain every eligible transition
- add `num_phantoms=None` to state/result MC evidence sampling; explicit values physically slice `log_L_phantom[:, :p]` before JIT and classic conditioning remains independent
- migrate repository benchmarks, document collection/storage versus evidence-time computation, and preserve deprecated `phantom_burn_in` with validation and a warning

## Correctness evidence
- new tests cover start-prefix ordering, final-classic exclusion, bounds/deprecation, automatic/custom resolved defaults, conflicting capacities, Python-static integer metadata, Pytree/checkpoint round trips, State/Results forwarding, exact physical-slice equivalence, invalid requests, and classic run/evidence invariance
- `PYTHONPATH=/tmp/jaxns-issue-284/src conda run -n jaxns_py pytest -q cicd/tests`: 310 passed
- post-review sampler/core/reviewer run: 48 passed
- hosted CI: all required jobs passed on Python 3.10 through 3.14
- fatal hosted flake8 gate: 0 findings
- Ruff: all touched Python files pass (the full repository still has unrelated pre-existing findings)

## Performance evidence
The reproducible 8D completed-result benchmark uses N=512 classic samples, G=512 blocks, P=8 retained states, and 256 draws in batches of 64. Public prefix selection is asserted draw-for-draw equal to a physically sliced result.

- p=1: 0.1333 s steady median; 10.41 MB compiler-planned peak
- p=8: 0.1413 s steady median; 13.59 MB compiler-planned peak

The shorter prefix removes 23.4% of compiler-planned peak memory. Runtime ranges overlap, while XLA input/temporary sizes directly confirm the unused suffix is absent from the compiled plan. Full details are in `benchmarks/issue_284/REPORT.md`.

Closes #284
